### PR TITLE
Add Cocoapods pod spec

### DIFF
--- a/JavaScriptCore-iOS.podspec
+++ b/JavaScriptCore-iOS.podspec
@@ -1,0 +1,39 @@
+Pod::Spec.new do |s|
+  s.name           = "JavaScriptCore-iOS"
+  s.version        = "0.0.1"
+  s.summary        = "Apple's JavaScript Engine, with modified project files for iOS."
+  s.description    = "Apple's JavaScript Engine, with modified project files for iOS. Also includes JavaScript's Typed Arrays which are normally a part of WebKit, not of JavaScriptCore."
+  s.homepage       = "https://github.com/phoboslab/JavaScriptCore-iOS"
+  s.authors        = "WebKit Team"
+  s.license        = { :type => 'LGPL', :file => 'JavaScriptCore/COPYING.LIB' }
+  s.source         = { :git => "https://github.com/phoboslab/JavaScriptCore-iOS.git", :tag => "#{s.version}" }
+  s.platform       = :ios, '5.0'
+  s.source_files   = 'JavaScriptCore/API/*.h'
+  s.header_dir     = 'JavaScriptCore'
+  s.preserve_paths = 'Build/libJavaScriptCore.a'
+  s.libraries      = 'stdc++', 'icucore', 'JavaScriptCore'
+  s.requires_arc   = false
+  s.xcconfig       =  { 'LIBRARY_SEARCH_PATHS' => '"$(PODS_ROOT)/JavaScriptCore-iOS/Build"' }
+
+
+  def s.pre_install(pod, target_definition)
+    Dir.chdir(pod.root) do
+      system <<CMD
+mkdir Build
+
+xcodebuild -project WTF/WTF.xcodeproj -alltargets clean
+xcodebuild -project WTF/WTF.xcodeproj -target "WTF iOS" -configuration Release -sdk iphoneos
+xcodebuild -project WTF/WTF.xcodeproj -target "WTF iOS" -configuration Release -sdk iphonesimulator -arch i386
+xcodebuild -project WTF/WTF.xcodeproj -target "Combine iOS lib" -configuration Release
+
+xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -alltargets clean
+xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -target "JavaScriptCore iOS" -configuration Release -sdk iphoneos
+xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -target "JavaScriptCore iOS" -configuration Release -sdk iphonesimulator -arch i386
+xcodebuild -project JavaScriptCore/JavaScriptCore.xcodeproj -target "Combine iOS lib" -configuration Release
+
+echo "DONE!"
+CMD
+    end
+  end
+end
+

--- a/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -5195,7 +5195,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = JavaScriptCore;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Debug;
 		};
@@ -5219,7 +5219,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = JavaScriptCore;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Release;
 		};
@@ -5243,7 +5243,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = JavaScriptCore;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Profiling;
 		};
@@ -5267,7 +5267,7 @@
 				OTHER_LDFLAGS = "";
 				PRODUCT_NAME = JavaScriptCore;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Production;
 		};
@@ -5286,7 +5286,7 @@
 				LIBRARY_SEARCH_PATHS = "$(SOURCE_ROOT)/../WTF";
 				PRODUCT_NAME = JSCLLIntOffsetsExtractor;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Debug;
 		};
@@ -5305,7 +5305,7 @@
 				LIBRARY_SEARCH_PATHS = "$(SOURCE_ROOT)/../WTF";
 				PRODUCT_NAME = JSCLLIntOffsetsExtractor;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Release;
 		};
@@ -5324,7 +5324,7 @@
 				LIBRARY_SEARCH_PATHS = "$(SOURCE_ROOT)/../WTF";
 				PRODUCT_NAME = JSCLLIntOffsetsExtractor;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Profiling;
 		};
@@ -5343,7 +5343,7 @@
 				LIBRARY_SEARCH_PATHS = "$(SOURCE_ROOT)/../WTF";
 				PRODUCT_NAME = JSCLLIntOffsetsExtractor;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Production;
 		};

--- a/WTF/WTF.xcodeproj/project.pbxproj
+++ b/WTF/WTF.xcodeproj/project.pbxproj
@@ -1754,6 +1754,7 @@
 			baseConfigurationReference = 5D247B7314689C4700E78B76 /* WTF.xcconfig */;
 			buildSettings = {
 				DEBUG_DEFINES = "$(DEBUG_DEFINES_debug)";
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 			};
 			name = Debug;
 		};
@@ -1761,6 +1762,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7314689C4700E78B76 /* WTF.xcconfig */;
 			buildSettings = {
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 			};
 			name = Release;
 		};
@@ -1775,6 +1777,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 5D247B7314689C4700E78B76 /* WTF.xcconfig */;
 			buildSettings = {
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 			};
 			name = Production;
 		};
@@ -1791,6 +1794,7 @@
 					"$(GCC_PREPROCESSOR_DEFINITIONS)",
 					"UCONFIG_NO_COLLATION=1",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = WTF;
 				SDKROOT = iphoneos;
@@ -1810,6 +1814,7 @@
 					"$(GCC_PREPROCESSOR_DEFINITIONS)",
 					"UCONFIG_NO_COLLATION=1",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = WTF;
 				SDKROOT = iphoneos;
@@ -1829,6 +1834,7 @@
 					"$(GCC_PREPROCESSOR_DEFINITIONS)",
 					"UCONFIG_NO_COLLATION=1",
 				);
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = WTF;
 				SDKROOT = iphoneos;
@@ -1839,6 +1845,7 @@
 		B6E69980166BD499005EF4B1 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -1846,6 +1853,7 @@
 		B6E69981166BD499005EF4B1 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;
@@ -1853,6 +1861,7 @@
 		B6E69982166BD499005EF4B1 /* Production */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				GCC_TREAT_WARNINGS_AS_ERRORS = NO;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Production;

--- a/WTF/WTF.xcodeproj/project.pbxproj
+++ b/WTF/WTF.xcodeproj/project.pbxproj
@@ -1794,7 +1794,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = WTF;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Debug;
 		};
@@ -1813,7 +1813,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = WTF;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Release;
 		};
@@ -1832,7 +1832,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
 				PRODUCT_NAME = WTF;
 				SDKROOT = iphoneos;
-				VALID_ARCHS = armv7;
+				VALID_ARCHS = "armv7 i386";
 			};
 			name = Production;
 		};


### PR DESCRIPTION
Supporting [Cocoapods](http://cocoapods.org/) would make it easier to use JavaScriptCore-iOS as a dependency in other projects.

If, for example, Ejecta used Cocoapods it's [podfile](http://docs.cocoapods.org/podfile.html) could look like this:

``` ruby
platform :ios, '5.0'
pod 'SocketRocket', '~> 0.2.0'
pod 'JavaScriptCore-iOS', :git => 'https://github.com/phoboslab/JavaScriptCore-iOS.git', '~> 0.0.1'
```

Currently the [pod spec](http://docs.cocoapods.org/specification.html) depends on this repository having tag `0.0.1` which would need to be added after merging this to make the spec work.

As a possible next step, it would also be cool if this project could be [added](https://github.com/CocoaPods/CocoaPods/wiki/Contributing-to-the-master-repo) to the [Cocoapods master repo](https://github.com/CocoaPods/Specs).
