### PR TITLE
[TVOS] Adds tvOS compatibility.

### DIFF
--- a/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
+++ b/JavaScriptCore/JavaScriptCore.xcodeproj/project.pbxproj
@@ -2115,6 +2115,1212 @@
 		A1712B4111C7B235007A5315 /* RegExpKey.h in Headers */ = {isa = PBXBuildFile; fileRef = A1712B4011C7B235007A5315 /* RegExpKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1A009C01831A22D00CF8711 /* MacroAssemblerARM64.h in Headers */ = {isa = PBXBuildFile; fileRef = 8640923C156EED3B00566CB2 /* MacroAssemblerARM64.h */; settings = {ATTRIBUTES = (Private, ); }; };
 		A1A009C11831A26E00CF8711 /* ARM64Assembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8640923B156EED3B00566CB2 /* ARM64Assembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3B645F61BCDBA50001827C5 /* libWTF-tvOS.a in Frameworks */ = {isa = PBXBuildFile; fileRef = A3B645F51BCDBA50001827C5 /* libWTF-tvOS.a */; };
+		A3CA46B61BCD9DC9004C5B45 /* A64DOpcode.h in Headers */ = {isa = PBXBuildFile; fileRef = 652A3A231651C69700A80AFE /* A64DOpcode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46B71BCD9DC9004C5B45 /* AbstractMacroAssembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 860161DF0F3A83C100F84710 /* AbstractMacroAssembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46B81BCD9DC9004C5B45 /* JSTypedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 104A28CB188A011B002CCBE0 /* JSTypedArray.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA46B91BCD9DC9004C5B45 /* AbstractPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F55F0F214D1063600AC7649 /* AbstractPC.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46BA1BCD9DC9004C5B45 /* APICallbackFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = C211B574176A224D000E2A23 /* APICallbackFunction.h */; };
+		A3CA46BB1BCD9DC9004C5B45 /* APICast.h in Headers */ = {isa = PBXBuildFile; fileRef = 1482B78A0A4305AB00517CFC /* APICast.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46BC1BCD9DC9004C5B45 /* APIShims.h in Headers */ = {isa = PBXBuildFile; fileRef = 865F408710E7D56300947361 /* APIShims.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46BD1BCD9DC9004C5B45 /* ArgList.h in Headers */ = {isa = PBXBuildFile; fileRef = BCF605120E203EF800B9A64D /* ArgList.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46BE1BCD9DC9004C5B45 /* Arguments.h in Headers */ = {isa = PBXBuildFile; fileRef = BC257DE60E1F51C50016B6C9 /* Arguments.h */; };
+		A3CA46BF1BCD9DC9004C5B45 /* ArgumentsIteratorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A76140C8182982CB00750624 /* ArgumentsIteratorConstructor.h */; };
+		A3CA46C01BCD9DC9004C5B45 /* ArgumentsIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A76140CA182982CB00750624 /* ArgumentsIteratorPrototype.h */; };
+		A3CA46C11BCD9DC9004C5B45 /* ARMAssembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D3B2C010156BDE002865E7 /* ARMAssembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46C21BCD9DC9004C5B45 /* ARMv7Assembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 86ADD1430FDDEA980006EEC2 /* ARMv7Assembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46C31BCD9DC9004C5B45 /* ARMv7DOpcode.h in Headers */ = {isa = PBXBuildFile; fileRef = 65C0285B1717966800351E35 /* ARMv7DOpcode.h */; };
+		A3CA46C41BCD9DC9004C5B45 /* CopyWriteBarrier.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A68295A1875F80500B6C3E2 /* CopyWriteBarrier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46C51BCD9DC9004C5B45 /* WriteBarrierBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A4EC90A1860D6C20094F782 /* WriteBarrierBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46C61BCD9DC9004C5B45 /* VMEntryScope.h in Headers */ = {isa = PBXBuildFile; fileRef = FE5932A6183C5A2600A1ECCC /* VMEntryScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46C71BCD9DC9004C5B45 /* CodeGeneratorInspectorStrings.py in Headers */ = {isa = PBXBuildFile; fileRef = A5324390185696E6002ED692 /* CodeGeneratorInspectorStrings.py */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46C81BCD9DC9004C5B45 /* CodeGeneratorInspector.py in Headers */ = {isa = PBXBuildFile; fileRef = A532438F185696E6002ED692 /* CodeGeneratorInspector.py */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46C91BCD9DC9004C5B45 /* TempRegisterSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E54817EE274900ABB217 /* TempRegisterSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46CA1BCD9DC9004C5B45 /* DFGFiltrationResult.h in Headers */ = {isa = PBXBuildFile; fileRef = A7BFF3BF179868940002F462 /* DFGFiltrationResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46CB1BCD9DC9004C5B45 /* BytecodeBasicBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = C2FCAE0D17A9C24E0034C735 /* BytecodeBasicBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46CC1BCD9DC9004C5B45 /* generate-combined-inspector-json.py in Headers */ = {isa = PBXBuildFile; fileRef = A5324391185696E6002ED692 /* generate-combined-inspector-json.py */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46CD1BCD9DC9004C5B45 /* BytecodeLivenessAnalysis.h in Headers */ = {isa = PBXBuildFile; fileRef = C2FCAE0F17A9C24E0034C735 /* BytecodeLivenessAnalysis.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46CE1BCD9DC9004C5B45 /* ArrayAllocationProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8335B51639C1E3001443B5 /* ArrayAllocationProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46CF1BCD9DC9004C5B45 /* Breakpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = FEA0861E182B7A0400F6D851 /* Breakpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46D01BCD9DC9004C5B45 /* ArrayBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF2617ADB5F3005AB174 /* ArrayBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46D11BCD9DC9004C5B45 /* DebuggerPrimitives.h in Headers */ = {isa = PBXBuildFile; fileRef = FEA0861F182B7A0400F6D851 /* DebuggerPrimitives.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46D21BCD9DC9004C5B45 /* ArrayBufferView.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF2817ADB5F3005AB174 /* ArrayBufferView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46D31BCD9DC9004C5B45 /* ArrayConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC7952070E15E8A800A898AB /* ArrayConstructor.h */; };
+		A3CA46D41BCD9DC9004C5B45 /* ArrayConventions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38915ED8E3800F167B2 /* ArrayConventions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46D51BCD9DC9004C5B45 /* ArrayIteratorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A7BDAEC117F4EA1400F6140C /* ArrayIteratorConstructor.h */; };
+		A3CA46D61BCD9DC9004C5B45 /* ArrayIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A7BDAEC317F4EA1400F6140C /* ArrayIteratorPrototype.h */; };
+		A3CA46D71BCD9DC9004C5B45 /* ArrayProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F63945215D07051006A597C /* ArrayProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46D81BCD9DC9004C5B45 /* ArrayPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A84E0255597D01FF60F7 /* ArrayPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46D91BCD9DC9004C5B45 /* ArrayPrototype.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = BC18C5230E16FC8A00B34460 /* ArrayPrototype.lut.h */; };
+		A3CA46DA1BCD9DC9004C5B45 /* ArrayStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38A15ED8E3800F167B2 /* ArrayStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46DB1BCD9DC9004C5B45 /* AssemblerBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 9688CB130ED12B4E001D649F /* AssemblerBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46DC1BCD9DC9004C5B45 /* AssemblerBufferWithConstantPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D3B2C110156BDE002865E7 /* AssemblerBufferWithConstantPool.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46DD1BCD9DC9004C5B45 /* AssemblyHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E53C17EA9F5900ABB217 /* AssemblyHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46DE1BCD9DC9004C5B45 /* ASTBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A7EE7411B98B8D0065A14F /* ASTBuilder.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46DF1BCD9DC9004C5B45 /* BatchedTransitionOptimizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 147B83AA0E6DB8C9004775A4 /* BatchedTransitionOptimizer.h */; };
+		A3CA46E01BCD9DC9004C5B45 /* BigInteger.h in Headers */ = {isa = PBXBuildFile; fileRef = 866739D013BFDE710023D87C /* BigInteger.h */; };
+		A3CA46E11BCD9DC9004C5B45 /* BlockAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 14816E1A154CC56C00B8054C /* BlockAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46E21BCD9DC9004C5B45 /* BooleanObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 704FD35305697E6D003DBED9 /* BooleanObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46E31BCD9DC9004C5B45 /* RemoteInspectorConstants.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BA15E3182340B300A82E69 /* RemoteInspectorConstants.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46E41BCD9DC9004C5B45 /* Butterfly.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38B15ED8E3800F167B2 /* Butterfly.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46E51BCD9DC9004C5B45 /* ButterflyInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38C15ED8E3800F167B2 /* ButterflyInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46E61BCD9DC9004C5B45 /* BytecodeConventions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F21C27E14BEAA8000ADC64B /* BytecodeConventions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46E71BCD9DC9004C5B45 /* BytecodeGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07210ED1CE3300F1F681 /* BytecodeGenerator.h */; };
+		A3CA46E81BCD9DC9004C5B45 /* ByValInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8023E91613832300A0BA45 /* ByValInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46E91BCD9DC9004C5B45 /* CallData.h in Headers */ = {isa = PBXBuildFile; fileRef = 145C507F0D9DF63B0088F6B9 /* CallData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46EA1BCD9DC9004C5B45 /* CallFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 1429D8DC0ED2205B00B89619 /* CallFrame.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46EB1BCD9DC9004C5B45 /* CallFrameInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = A7C1EAEA17987AB600299DB2 /* CallFrameInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46EC1BCD9DC9004C5B45 /* CallIdentifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 95E3BC040E1AE68200B2D1C1 /* CallIdentifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46ED1BCD9DC9004C5B45 /* CallLinkInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B83AF14BCF71400885B4F /* CallLinkInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46EE1BCD9DC9004C5B45 /* CallLinkStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F93329414CA7DC10085F3C6 /* CallLinkStatus.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46EF1BCD9DC9004C5B45 /* CallReturnOffsetToBytecodeOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B83B814BCF95B00885B4F /* CallReturnOffsetToBytecodeOffset.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F01BCD9DC9004C5B45 /* CCallHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E53D17EA9F5900ABB217 /* CCallHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F11BCD9DC9004C5B45 /* ClassInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = BC6AAAE40E1F426500AD87D8 /* ClassInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F21BCD9DC9004C5B45 /* ClosureCallStubRoutine.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F73D7AC165A142A00ACAB71 /* ClosureCallStubRoutine.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F31BCD9DC9004C5B45 /* CodeBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07910ED1D3AE00F1F681 /* CodeBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F41BCD9DC9004C5B45 /* CodeBlockHash.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8F943E1667632D00D61971 /* CodeBlockHash.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F51BCD9DC9004C5B45 /* CodeBlockJettisoningWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC97F30182020D7002C9B26 /* CodeBlockJettisoningWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F61BCD9DC9004C5B45 /* CodeBlockSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD8A31217D4326C00CA2C40 /* CodeBlockSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F71BCD9DC9004C5B45 /* CodeBlockWithJITType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F96EBB116676EF4008BADE3 /* CodeBlockWithJITType.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F81BCD9DC9004C5B45 /* CodeCache.h in Headers */ = {isa = PBXBuildFile; fileRef = A77F1820164088B200640A47 /* CodeCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46F91BCD9DC9004C5B45 /* CodeLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E116B00FE75AC800B512BC /* CodeLocation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46FA1BCD9DC9004C5B45 /* CodeOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FBD7E671447998F00481315 /* CodeOrigin.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46FB1BCD9DC9004C5B45 /* CodeSpecializationKind.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F21C27914BE727300ADC64B /* CodeSpecializationKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46FC1BCD9DC9004C5B45 /* CodeType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B83A514BCF50400885B4F /* CodeType.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46FD1BCD9DC9004C5B45 /* CommonIdentifiers.h in Headers */ = {isa = PBXBuildFile; fileRef = 65EA73630BAE35D1001BB560 /* CommonIdentifiers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46FE1BCD9DC9004C5B45 /* CommonSlowPaths.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F15F15D14B7A73A005DE37D /* CommonSlowPaths.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA46FF1BCD9DC9004C5B45 /* CommonSlowPathsExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 6553A33017A1F1EE008CF6F3 /* CommonSlowPathsExceptions.h */; };
+		A3CA47001BCD9DC9004C5B45 /* CompactJITCodeMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD82E37141AB14200179C94 /* CompactJITCodeMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47011BCD9DC9004C5B45 /* CompilationResult.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E5A3A61797432D00E893C0 /* CompilationResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47021BCD9DC9004C5B45 /* Completion.h in Headers */ = {isa = PBXBuildFile; fileRef = F5BB2BC5030F772101FCFE1D /* Completion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47031BCD9DC9004C5B45 /* ConcurrentJITLock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDB2CE9174896C7007B3C1B /* ConcurrentJITLock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47041BCD9DC9004C5B45 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = F68EBB8C0255D4C601FF60F7 /* config.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47051BCD9DC9004C5B45 /* ConservativeRoots.h in Headers */ = {isa = PBXBuildFile; fileRef = 149DAAF212EB559D0083B12B /* ConservativeRoots.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47061BCD9DC9004C5B45 /* ConstructData.h in Headers */ = {isa = PBXBuildFile; fileRef = BC8F3CCF0DAF17BA00577A80 /* ConstructData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47071BCD9DC9004C5B45 /* CopiedAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = C2EAD2FB14F0249800A4B159 /* CopiedAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47081BCD9DC9004C5B45 /* CopiedBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = C2C8D02E14A3CEFC00578E65 /* CopiedBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47091BCD9DC9004C5B45 /* CopiedBlockInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = C2FC9BD216644DFB00810D33 /* CopiedBlockInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA470A1BCD9DC9004C5B45 /* CopiedSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = C2EAA3F8149A830800FCE112 /* CopiedSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA470B1BCD9DC9004C5B45 /* CopiedSpaceInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = C2C8D02B14A3C6B200578E65 /* CopiedSpaceInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA470C1BCD9DC9004C5B45 /* CopyToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5A52CF17ADD717008ECB2D /* CopyToken.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA470D1BCD9DC9004C5B45 /* CopyVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = C2239D1316262BDD005AC5FD /* CopyVisitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA470E1BCD9DC9004C5B45 /* CopyVisitorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = C2239D1416262BDD005AC5FD /* CopyVisitorInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA470F1BCD9DC9004C5B45 /* CopyWorkList.h in Headers */ = {isa = PBXBuildFile; fileRef = C218D13F1655CFD50062BB81 /* CopyWorkList.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47101BCD9DC9004C5B45 /* create_hash_table in Headers */ = {isa = PBXBuildFile; fileRef = F692A8540255597D01FF60F7 /* create_hash_table */; settings = {ATTRIBUTES = (); }; };
+		A3CA47111BCD9DC9004C5B45 /* DataFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F426A4A1460CD6B00131F8F /* DataFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47121BCD9DC9004C5B45 /* DataView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66B117B6B5AB00A7AE3F /* DataView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47131BCD9DC9004C5B45 /* DateConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD203460E17135E002C7E82 /* DateConstructor.h */; };
+		A3CA47141BCD9DC9004C5B45 /* DateConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = D21202290AD4310C00ED79B6 /* DateConversion.h */; };
+		A3CA47151BCD9DC9004C5B45 /* InspectorAgentBase.h in Headers */ = {isa = PBXBuildFile; fileRef = A593CF7E1840362C00BFCE27 /* InspectorAgentBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47161BCD9DC9004C5B45 /* DateInstance.h in Headers */ = {isa = PBXBuildFile; fileRef = BC1166010E1997B1008066DD /* DateInstance.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47171BCD9DC9004C5B45 /* DateInstanceCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 14A1563010966365006FA260 /* DateInstanceCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47181BCD9DC9004C5B45 /* DatePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD203480E17135E002C7E82 /* DatePrototype.h */; };
+		A3CA47191BCD9DC9004C5B45 /* DatePrototype.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD203E70E1718F4002C7E82 /* DatePrototype.lut.h */; };
+		A3CA471A1BCD9DC9004C5B45 /* Debugger.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A8590255597D01FF60F7 /* Debugger.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA471B1BCD9DC9004C5B45 /* DebuggerActivation.h in Headers */ = {isa = PBXBuildFile; fileRef = BC3135620F302FA3003DFD3A /* DebuggerActivation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA471C1BCD9DC9004C5B45 /* DebuggerCallFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 1480DB9B0DDC227F003CFDF2 /* DebuggerCallFrame.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA471D1BCD9DC9004C5B45 /* DeferGC.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F136D4B174AD69B0075B354 /* DeferGC.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA471E1BCD9DC9004C5B45 /* BytecodeUseDef.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F885E101849A3BE00F1E3FA /* BytecodeUseDef.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA471F1BCD9DC9004C5B45 /* DeferredCompilationCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC712DD17CD8778008CC93C /* DeferredCompilationCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47201BCD9DC9004C5B45 /* DFGAbstractHeap.h in Headers */ = {isa = PBXBuildFile; fileRef = A77A423717A0BBFD00A8DB81 /* DFGAbstractHeap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47211BCD9DC9004C5B45 /* DFGAbstractInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = A704D8FE17A0BAA8006BA554 /* DFGAbstractInterpreter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47221BCD9DC9004C5B45 /* DFGAbstractInterpreterInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = A704D8FF17A0BAA8006BA554 /* DFGAbstractInterpreterInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47231BCD9DC9004C5B45 /* DFGAbstractValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F62016F143FCD2F0068B77C /* DFGAbstractValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47241BCD9DC9004C5B45 /* DFGAdjacencyList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F66E16814DF3F1300B7B2E4 /* DFGAdjacencyList.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47251BCD9DC9004C5B45 /* DFGAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB4B51916B62772003F696B /* DFGAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47261BCD9DC9004C5B45 /* DFGAnalysis.h in Headers */ = {isa = PBXBuildFile; fileRef = A73781091799EA2E00817533 /* DFGAnalysis.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47271BCD9DC9004C5B45 /* DFGArgumentPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F1E3A431534CBAD000F9456 /* DFGArgumentPosition.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47281BCD9DC9004C5B45 /* DFGArgumentsSimplificationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F16015B156198BF00C2587C /* DFGArgumentsSimplificationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47291BCD9DC9004C5B45 /* DFGArrayifySlowPathGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F05C3B21683CF8F00BAF45B /* DFGArrayifySlowPathGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA472A1BCD9DC9004C5B45 /* DFGArrayMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F63948215E48114006A597C /* DFGArrayMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA472B1BCD9DC9004C5B45 /* RemoteInspectorDebuggableConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BA15E4182340B300A82E69 /* RemoteInspectorDebuggableConnection.h */; };
+		A3CA472C1BCD9DC9004C5B45 /* DFGAtTailAbstractState.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D9A29017A0BC7400EE2618 /* DFGAtTailAbstractState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA472D1BCD9DC9004C5B45 /* DFGBackwardsPropagationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F714CA216EA92ED00F3EBEB /* DFGBackwardsPropagationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA472E1BCD9DC9004C5B45 /* DFGBasicBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F620170143FCD2F0068B77C /* DFGBasicBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA472F1BCD9DC9004C5B45 /* DFGBasicBlockInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD5652216AB780A00197653 /* DFGBasicBlockInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47301BCD9DC9004C5B45 /* DFGBinarySwitch.h in Headers */ = {isa = PBXBuildFile; fileRef = A70B083117A0B79B00DAF14B /* DFGBinarySwitch.h */; };
+		A3CA47311BCD9DC9004C5B45 /* DFGBlockInsertionSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D89CE517A0B8CC00773AD8 /* DFGBlockInsertionSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47321BCD9DC9004C5B45 /* DFGBranchDirection.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8364B5164B0C0E0053329A /* DFGBranchDirection.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47331BCD9DC9004C5B45 /* MacroAssemblerARM64.h in Headers */ = {isa = PBXBuildFile; fileRef = 8640923C156EED3B00566CB2 /* MacroAssemblerARM64.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47341BCD9DC9004C5B45 /* DFGByteCodeParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EC9DB51328DF82002B2AD7 /* DFGByteCodeParser.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47351BCD9DC9004C5B45 /* InspectorAgentRegistry.h in Headers */ = {isa = PBXBuildFile; fileRef = A593CF85184038CA00BFCE27 /* InspectorAgentRegistry.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47361BCD9DC9004C5B45 /* DFGCallArrayAllocatorSlowPathGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F256C341627B0AA007F2783 /* DFGCallArrayAllocatorSlowPathGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47371BCD9DC9004C5B45 /* DFGCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD82E1F14172C2F00179C94 /* DFGCapabilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47381BCD9DC9004C5B45 /* DFGCFAPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFFC94C14EF909500C72532 /* DFGCFAPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47391BCD9DC9004C5B45 /* DFGCFGSimplificationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F3B3A251544C991003ED0FF /* DFGCFGSimplificationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA473A1BCD9DC9004C5B45 /* DFGClobberize.h in Headers */ = {isa = PBXBuildFile; fileRef = A77A423917A0BBFD00A8DB81 /* DFGClobberize.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA473B1BCD9DC9004C5B45 /* DFGClobberSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A77A423B17A0BBFD00A8DB81 /* DFGClobberSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA473C1BCD9DC9004C5B45 /* DFGCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC0977E1469EBC400CF2442 /* DFGCommon.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA473D1BCD9DC9004C5B45 /* DFGCommonData.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A2E170D40BF00BB722C /* DFGCommonData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA473E1BCD9DC9004C5B45 /* DFGCompilationKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F38B01417CFE75500B144D3 /* DFGCompilationKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA473F1BCD9DC9004C5B45 /* DFGCompilationMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F38B01617CFE75500B144D3 /* DFGCompilationMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47401BCD9DC9004C5B45 /* DFGConstantFoldingPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F3B3A18153E68EF003ED0FF /* DFGConstantFoldingPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47411BCD9DC9004C5B45 /* DFGCPSRethreadingPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FBE0F6C16C1DB010082C5E8 /* DFGCPSRethreadingPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47421BCD9DC9004C5B45 /* DFGCriticalEdgeBreakingPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D89CE717A0B8CC00773AD8 /* DFGCriticalEdgeBreakingPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47431BCD9DC9004C5B45 /* DFGCSEPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFFC94E14EF909500C72532 /* DFGCSEPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47441BCD9DC9004C5B45 /* DFGDCEPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2FC77116E12F6F0038D976 /* DFGDCEPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47451BCD9DC9004C5B45 /* DFGDesiredIdentifiers.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8F2B98172F04FD007DBDA5 /* DFGDesiredIdentifiers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47461BCD9DC9004C5B45 /* DFGDesiredStructureChains.h in Headers */ = {isa = PBXBuildFile; fileRef = A73E132D179624CD00E4DEA8 /* DFGDesiredStructureChains.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47471BCD9DC9004C5B45 /* DFGDesiredTransitions.h in Headers */ = {isa = PBXBuildFile; fileRef = C2C0F7CC17BBFC5B00464FE4 /* DFGDesiredTransitions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47481BCD9DC9004C5B45 /* DFGDesiredWatchpoints.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE8534A1723CDA500B618F5 /* DFGDesiredWatchpoints.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47491BCD9DC9004C5B45 /* DFGSSALoweringPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC20CB818556A3500C9E954 /* DFGSSALoweringPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA474A1BCD9DC9004C5B45 /* DFGDesiredWeakReferences.h in Headers */ = {isa = PBXBuildFile; fileRef = C2981FD717BAEE4B00A3BC98 /* DFGDesiredWeakReferences.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA474B1BCD9DC9004C5B45 /* DFGDesiredWriteBarriers.h in Headers */ = {isa = PBXBuildFile; fileRef = C2981FDB17BAFF4400A3BC98 /* DFGDesiredWriteBarriers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA474C1BCD9DC9004C5B45 /* DFGDisassembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF427621591A1C9004CB9FF /* DFGDisassembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA474D1BCD9DC9004C5B45 /* DFGDominators.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD81AD0154FB4EB00983E72 /* DFGDominators.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA474E1BCD9DC9004C5B45 /* DFGDoubleFormatState.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F1E3A441534CBAD000F9456 /* DFGDoubleFormatState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA474F1BCD9DC9004C5B45 /* DFGDriver.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD3C82214115D0E00FD81CB /* DFGDriver.h */; };
+		A3CA47501BCD9DC9004C5B45 /* DFGEdge.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F66E16914DF3F1300B7B2E4 /* DFGEdge.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47511BCD9DC9004C5B45 /* DFGEdgeDominates.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D9A29117A0BC7400EE2618 /* DFGEdgeDominates.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47521BCD9DC9004C5B45 /* DFGEdgeUsesStructure.h in Headers */ = {isa = PBXBuildFile; fileRef = A7986D5617A0BB1E00A95DD0 /* DFGEdgeUsesStructure.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47531BCD9DC9004C5B45 /* DFGExitProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FBC0AE51496C7C100D4FBDD /* DFGExitProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47541BCD9DC9004C5B45 /* DFGFailedFinalizer.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A976D179738B8009DF744 /* DFGFailedFinalizer.h */; };
+		A3CA47551BCD9DC9004C5B45 /* DFGFinalizer.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A976F179738B8009DF744 /* DFGFinalizer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47561BCD9DC9004C5B45 /* DFGFixupPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC13151C5D4A00CD8910 /* DFGFixupPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47571BCD9DC9004C5B45 /* DFGFlushedAt.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9D339517FFC4E60073C2BC /* DFGFlushedAt.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47581BCD9DC9004C5B45 /* DFGFlushFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D89CE917A0B8CC00773AD8 /* DFGFlushFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47591BCD9DC9004C5B45 /* DFGFlushLivenessAnalysisPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D89CEB17A0B8CC00773AD8 /* DFGFlushLivenessAnalysisPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA475A1BCD9DC9004C5B45 /* DFGGenerationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EC9DB61328DF82002B2AD7 /* DFGGenerationInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA475B1BCD9DC9004C5B45 /* DFGGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EC9DB81328DF82002B2AD7 /* DFGGraph.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA475C1BCD9DC9004C5B45 /* DFGInlineCacheWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB14E201812570B009B6B4D /* DFGInlineCacheWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA475D1BCD9DC9004C5B45 /* DFGInlineCacheWrapperInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB14E2218130955009B6B4D /* DFGInlineCacheWrapperInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA475E1BCD9DC9004C5B45 /* DFGInPlaceAbstractState.h in Headers */ = {isa = PBXBuildFile; fileRef = A704D90117A0BAA8006BA554 /* DFGInPlaceAbstractState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA475F1BCD9DC9004C5B45 /* DFGInsertionSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC1F151E803800CD8910 /* DFGInsertionSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47601BCD9DC9004C5B45 /* DFGInvalidationPointInjectionPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC97F3818202119002C9B26 /* DFGInvalidationPointInjectionPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47611BCD9DC9004C5B45 /* DFGJITCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A30170D40BF00BB722C /* DFGJITCode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47621BCD9DC9004C5B45 /* DFGJITCompiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EC9DBC1328DF82002B2AD7 /* DFGJITCompiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47631BCD9DC9004C5B45 /* DFGJITFinalizer.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A9771179738B8009DF744 /* DFGJITFinalizer.h */; };
+		A3CA47641BCD9DC9004C5B45 /* DFGJumpReplacement.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC97F3A18202119002C9B26 /* DFGJumpReplacement.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47651BCD9DC9004C5B45 /* DFGLazyJSValue.h in Headers */ = {isa = PBXBuildFile; fileRef = A73A53591799CD5D00170C19 /* DFGLazyJSValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47661BCD9DC9004C5B45 /* DFGLICMPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D9A29317A0BC7400EE2618 /* DFGLICMPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47671BCD9DC9004C5B45 /* DFGLivenessAnalysisPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D89CED17A0B8CC00773AD8 /* DFGLivenessAnalysisPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47681BCD9DC9004C5B45 /* DFGLongLivedState.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB4B51D16B62772003F696B /* DFGLongLivedState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47691BCD9DC9004C5B45 /* DFGLoopPreHeaderCreationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = A767B5B417A0B9650063D940 /* DFGLoopPreHeaderCreationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA476A1BCD9DC9004C5B45 /* DFGMergeMode.h in Headers */ = {isa = PBXBuildFile; fileRef = A704D90217A0BAA8006BA554 /* DFGMergeMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA476B1BCD9DC9004C5B45 /* DFGMinifiedGraph.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC3D1522801700CD8910 /* DFGMinifiedGraph.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA476C1BCD9DC9004C5B45 /* DFGMinifiedID.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB4B51016B3A964003F696B /* DFGMinifiedID.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA476D1BCD9DC9004C5B45 /* DFGMinifiedNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC3E1522801700CD8910 /* DFGMinifiedNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA476E1BCD9DC9004C5B45 /* DFGNaturalLoops.h in Headers */ = {isa = PBXBuildFile; fileRef = A737810B1799EA2E00817533 /* DFGNaturalLoops.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA476F1BCD9DC9004C5B45 /* DFGNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 86ECA3E9132DEF1C002B2AD7 /* DFGNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47701BCD9DC9004C5B45 /* DFGNodeAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB4B51F16B62772003F696B /* DFGNodeAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47711BCD9DC9004C5B45 /* DFGNodeFlags.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA581B8150E952A00B9A2D9 /* DFGNodeFlags.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47721BCD9DC9004C5B45 /* DFGNodeType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA581B9150E952A00B9A2D9 /* DFGNodeType.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47731BCD9DC9004C5B45 /* DFGOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EC9DC01328DF82002B2AD7 /* DFGOperations.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47741BCD9DC9004C5B45 /* DFGOSRAvailabilityAnalysisPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D89CEF17A0B8CC00773AD8 /* DFGOSRAvailabilityAnalysisPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47751BCD9DC9004C5B45 /* DFGOSREntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD82E53141DAEDE00179C94 /* DFGOSREntry.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47761BCD9DC9004C5B45 /* DFGOSREntrypointCreationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD8A31E17D51F5700CA2C40 /* DFGOSREntrypointCreationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47771BCD9DC9004C5B45 /* DFGOSRExit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC097681468A6EF00CF2442 /* DFGOSRExit.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47781BCD9DC9004C5B45 /* ConstantMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFC99D0184EC8AD009C10AB /* ConstantMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47791BCD9DC9004C5B45 /* DFGOSRExitBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BE817178E7300690C7F /* DFGOSRExitBase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA477A1BCD9DC9004C5B45 /* RemoteInspectorXPCConnection.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BA15E6182340B300A82E69 /* RemoteInspectorXPCConnection.h */; };
+		A3CA477B1BCD9DC9004C5B45 /* DFGOSRExitCompilationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 65987F2C167FE84B003C2F8D /* DFGOSRExitCompilationInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA477C1BCD9DC9004C5B45 /* DFGOSRExitCompiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC0976F14693AEF00CF2442 /* DFGOSRExitCompiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA477D1BCD9DC9004C5B45 /* DFGOSRExitCompilerCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F7025A81714B0F800382C0E /* DFGOSRExitCompilerCommon.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA477E1BCD9DC9004C5B45 /* DFGOSRExitJumpPlaceholder.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEFC9A81681A3B000567F53 /* DFGOSRExitJumpPlaceholder.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA477F1BCD9DC9004C5B45 /* DFGOSRExitPreparation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BEA17178E7300690C7F /* DFGOSRExitPreparation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47801BCD9DC9004C5B45 /* DFGPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFFC95014EF909500C72532 /* DFGPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47811BCD9DC9004C5B45 /* DFGPlan.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A9773179738B8009DF744 /* DFGPlan.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47821BCD9DC9004C5B45 /* DFGPredictionInjectionPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FBE0F6E16C1DB010082C5E8 /* DFGPredictionInjectionPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47831BCD9DC9004C5B45 /* DFGPredictionPropagationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFFC95214EF909500C72532 /* DFGPredictionPropagationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47841BCD9DC9004C5B45 /* DFGRegisterBank.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EC9DC11328DF82002B2AD7 /* DFGRegisterBank.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47851BCD9DC9004C5B45 /* DFGSafeToExecute.h in Headers */ = {isa = PBXBuildFile; fileRef = A77A423C17A0BBFD00A8DB81 /* DFGSafeToExecute.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47861BCD9DC9004C5B45 /* DFGSaneStringGetByValSlowPathGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = A741017E179DAF80002EB8BA /* DFGSaneStringGetByValSlowPathGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47871BCD9DC9004C5B45 /* DFGScoreBoard.h in Headers */ = {isa = PBXBuildFile; fileRef = 86ECA3F9132DF25A002B2AD7 /* DFGScoreBoard.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47881BCD9DC9004C5B45 /* DFGSilentRegisterSavePlan.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F1E3A65153A21DF000F9456 /* DFGSilentRegisterSavePlan.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47891BCD9DC9004C5B45 /* DFGSlowPathGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F1E3A501537C2CB000F9456 /* DFGSlowPathGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA478A1BCD9DC9004C5B45 /* DFGSpeculativeJIT.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EC9DC31328DF82002B2AD7 /* DFGSpeculativeJIT.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA478B1BCD9DC9004C5B45 /* DFGSSAConversionPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D89CF117A0B8CC00773AD8 /* DFGSSAConversionPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA478C1BCD9DC9004C5B45 /* DFGStackLayoutPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9FB4F317FCB91700CB67F8 /* DFGStackLayoutPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA478D1BCD9DC9004C5B45 /* InspectorValues.h in Headers */ = {isa = PBXBuildFile; fileRef = A593CF811840377100BFCE27 /* InspectorValues.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA478E1BCD9DC9004C5B45 /* DFGStructureAbstractValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F63947615DCE347006A597C /* DFGStructureAbstractValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA478F1BCD9DC9004C5B45 /* DFGThunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC097A0146B28C700CF2442 /* DFGThunks.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47901BCD9DC9004C5B45 /* DFGTierUpCheckInjectionPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD8A32017D51F5700CA2C40 /* DFGTierUpCheckInjectionPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47911BCD9DC9004C5B45 /* DFGToFTLDeferredCompilationCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD8A32217D51F5700CA2C40 /* DFGToFTLDeferredCompilationCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47921BCD9DC9004C5B45 /* VariableWatchpointSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9181C618415CA50057B669 /* VariableWatchpointSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47931BCD9DC9004C5B45 /* DFGToFTLForOSREntryDeferredCompilationCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD8A32417D51F5700CA2C40 /* DFGToFTLForOSREntryDeferredCompilationCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47941BCD9DC9004C5B45 /* DFGTypeCheckHoistingPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F63943D15C75F14006A597C /* DFGTypeCheckHoistingPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47951BCD9DC9004C5B45 /* DFGUnificationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FBE0F7016C1DB010082C5E8 /* DFGUnificationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47961BCD9DC9004C5B45 /* DFGUseKind.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F34B14816D4200E001CDA5A /* DFGUseKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47971BCD9DC9004C5B45 /* DFGValidate.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F3B3A2A15474FF4003ED0FF /* DFGValidate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47981BCD9DC9004C5B45 /* DFGValueRecoveryOverride.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC3F1522801700CD8910 /* DFGValueRecoveryOverride.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47991BCD9DC9004C5B45 /* DFGValueSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC401522801700CD8910 /* DFGValueSource.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA479A1BCD9DC9004C5B45 /* DFGVariableAccessData.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F620172143FCD2F0068B77C /* DFGVariableAccessData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA479B1BCD9DC9004C5B45 /* DFGVariableAccessDataDump.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDDBFB31666EED500C55FEF /* DFGVariableAccessDataDump.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA479C1BCD9DC9004C5B45 /* DFGVariableEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC411522801700CD8910 /* DFGVariableEvent.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA479D1BCD9DC9004C5B45 /* DFGVariableEventStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC431522801700CD8910 /* DFGVariableEventStream.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA479E1BCD9DC9004C5B45 /* DFGVariadicFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F85A31E16AB76AE0077571E /* DFGVariadicFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA479F1BCD9DC9004C5B45 /* DFGVirtualRegisterAllocationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFFC95414EF909500C72532 /* DFGVirtualRegisterAllocationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A01BCD9DC9004C5B45 /* DFGWatchpointCollectionPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC97F3C18202119002C9B26 /* DFGWatchpointCollectionPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A11BCD9DC9004C5B45 /* DFGWorklist.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDB2CE6174830A2007B3C1B /* DFGWorklist.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A21BCD9DC9004C5B45 /* Disassembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF4272F158EBD44004CB9FF /* Disassembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A31BCD9DC9004C5B45 /* DumpContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A70447EC17A0BD7000F5898E /* DumpContext.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A41BCD9DC9004C5B45 /* Error.h in Headers */ = {isa = PBXBuildFile; fileRef = BC3046060E1F497F003232CF /* Error.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A51BCD9DC9004C5B45 /* ErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9050E1839DB000F9297 /* ErrorConstructor.h */; };
+		A3CA47A61BCD9DC9004C5B45 /* ErrorInstance.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E98B0E183E38000F9297 /* ErrorInstance.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A71BCD9DC9004C5B45 /* ErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9070E1839DB000F9297 /* ErrorPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A81BCD9DC9004C5B45 /* EvalCodeCache.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07920ED1D3AE00F1F681 /* EvalCodeCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47A91BCD9DC9004C5B45 /* ExceptionHelpers.h in Headers */ = {isa = PBXBuildFile; fileRef = A72701B30DADE94900E548D7 /* ExceptionHelpers.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47AA1BCD9DC9004C5B45 /* Executable.h in Headers */ = {isa = PBXBuildFile; fileRef = 86CAFEE21035DDE60028A609 /* Executable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47AB1BCD9DC9004C5B45 /* ExecutableAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = A7B48DB50EE74CFC00DCBDB6 /* ExecutableAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47AC1BCD9DC9004C5B45 /* ExecutionCounter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F56A1D115000F31002992B1 /* ExecutionCounter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47AD1BCD9DC9004C5B45 /* ExitKind.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB105831675480C00F8AB6E /* ExitKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47AE1BCD9DC9004C5B45 /* ExpressionRangeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B83AA14BCF5B900885B4F /* ExpressionRangeInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47AF1BCD9DC9004C5B45 /* Float32Array.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF2917ADB5F3005AB174 /* Float32Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B01BCD9DC9004C5B45 /* ScriptValue.h in Headers */ = {isa = PBXBuildFile; fileRef = A54CF2F3184EAB2400237F19 /* ScriptValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B11BCD9DC9004C5B45 /* Float64Array.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF2A17ADB5F3005AB174 /* Float64Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B21BCD9DC9004C5B45 /* FPRInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E53E17EA9F5900ABB217 /* FPRInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B31BCD9DC9004C5B45 /* ArrayBufferNeuteringWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FFC99D3184EE318009C10AB /* ArrayBufferNeuteringWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B41BCD9DC9004C5B45 /* FTLAbbreviatedTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDB2CC7173DA51E007B3C1B /* FTLAbbreviatedTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B51BCD9DC9004C5B45 /* FTLAbbreviations.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA09FD170513DB00BB722C /* FTLAbbreviations.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B61BCD9DC9004C5B45 /* FTLAbstractHeap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A181708B00700BB722C /* FTLAbstractHeap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B71BCD9DC9004C5B45 /* FTLAbstractHeapRepository.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A1A1708B00700BB722C /* FTLAbstractHeapRepository.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47B81BCD9DC9004C5B45 /* JSGlobalObjectDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = A59455911824744700CC3843 /* JSGlobalObjectDebuggable.h */; };
+		A3CA47B91BCD9DC9004C5B45 /* FTLCapabilities.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA09FF170513DB00BB722C /* FTLCapabilities.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47BA1BCD9DC9004C5B45 /* FTLCommonValues.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A211709606900BB722C /* FTLCommonValues.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47BB1BCD9DC9004C5B45 /* FTLCompile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A01170513DB00BB722C /* FTLCompile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47BC1BCD9DC9004C5B45 /* FTLExitArgument.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BBE17178E1C00690C7F /* FTLExitArgument.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47BD1BCD9DC9004C5B45 /* FTLExitArgumentForOperand.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BC017178E1C00690C7F /* FTLExitArgumentForOperand.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47BE1BCD9DC9004C5B45 /* FTLExitArgumentList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BC117178E1C00690C7F /* FTLExitArgumentList.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47BF1BCD9DC9004C5B45 /* FTLExitThunkGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BC317178E1C00690C7F /* FTLExitThunkGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C01BCD9DC9004C5B45 /* FTLExitValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BC517178E1C00690C7F /* FTLExitValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C11BCD9DC9004C5B45 /* FTLFail.h in Headers */ = {isa = PBXBuildFile; fileRef = A7F2996A17A0BB670010417A /* FTLFail.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C21BCD9DC9004C5B45 /* FTLFormattedValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A2B170B661900BB722C /* FTLFormattedValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C31BCD9DC9004C5B45 /* FTLForOSREntryJITCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD8A31617D51F2200CA2C40 /* FTLForOSREntryJITCode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C41BCD9DC9004C5B45 /* FTLGeneratedFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A977C179738D5009DF744 /* FTLGeneratedFunction.h */; };
+		A3CA47C51BCD9DC9004C5B45 /* FTLInlineCacheDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F25F1A7181635F300522F39 /* FTLInlineCacheDescriptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C61BCD9DC9004C5B45 /* FTLInlineCacheSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F25F1A9181635F300522F39 /* FTLInlineCacheSize.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C71BCD9DC9004C5B45 /* FTLIntrinsicRepository.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A221709606900BB722C /* FTLIntrinsicRepository.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C81BCD9DC9004C5B45 /* FTLJITCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A03170513DB00BB722C /* FTLJITCode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47C91BCD9DC9004C5B45 /* FTLJITFinalizer.h in Headers */ = {isa = PBXBuildFile; fileRef = A78A977E179738D5009DF744 /* FTLJITFinalizer.h */; };
+		A3CA47CA1BCD9DC9004C5B45 /* FTLLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8F2B94172E049E007DBDA5 /* FTLLink.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47CB1BCD9DC9004C5B45 /* FTLLocation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCEFADE180738C000472CE4 /* FTLLocation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47CC1BCD9DC9004C5B45 /* FTLLowerDFGToLLVM.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A05170513DB00BB722C /* FTLLowerDFGToLLVM.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47CD1BCD9DC9004C5B45 /* FTLLoweredNodeValue.h in Headers */ = {isa = PBXBuildFile; fileRef = A7D89D0117A0B90400773AD8 /* FTLLoweredNodeValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47CE1BCD9DC9004C5B45 /* FTLOSREntry.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD8A31817D51F2200CA2C40 /* FTLOSREntry.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47CF1BCD9DC9004C5B45 /* FTLOSRExit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BC717178E1C00690C7F /* FTLOSRExit.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D01BCD9DC9004C5B45 /* FTLOSRExitCompilationInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BC817178E1C00690C7F /* FTLOSRExitCompilationInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D11BCD9DC9004C5B45 /* FTLOSRExitCompiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BCA17178E1C00690C7F /* FTLOSRExitCompiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D21BCD9DC9004C5B45 /* FTLOutput.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A06170513DB00BB722C /* FTLOutput.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D31BCD9DC9004C5B45 /* FTLSaveRestore.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCEFAAA1804C13E00472CE4 /* FTLSaveRestore.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D41BCD9DC9004C5B45 /* FTLSlowPathCall.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F25F1AB181635F300522F39 /* FTLSlowPathCall.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D51BCD9DC9004C5B45 /* FTLSlowPathCallKey.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F25F1AD181635F300522F39 /* FTLSlowPathCallKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D61BCD9DC9004C5B45 /* FTLStackMaps.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9D33991803ADB70073C2BC /* FTLStackMaps.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D71BCD9DC9004C5B45 /* FTLState.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A07170513DB00BB722C /* FTLState.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D81BCD9DC9004C5B45 /* FTLSwitchCase.h in Headers */ = {isa = PBXBuildFile; fileRef = A7FCC26C17A0B6AA00786D1A /* FTLSwitchCase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47D91BCD9DC9004C5B45 /* FTLThunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BCC17178E1C00690C7F /* FTLThunks.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47DA1BCD9DC9004C5B45 /* FTLTypedPointer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FEA0A1B1708B00700BB722C /* FTLTypedPointer.h */; };
+		A3CA47DB1BCD9DC9004C5B45 /* FTLValueFormat.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F235BCE17178E1C00690C7F /* FTLValueFormat.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47DC1BCD9DC9004C5B45 /* FTLValueFromBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDB2CC8173DA51E007B3C1B /* FTLValueFromBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47DD1BCD9DC9004C5B45 /* FunctionConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2680C10E16D4E900A06E92 /* FunctionConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47DE1BCD9DC9004C5B45 /* FunctionExecutableDump.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB4B52216B6278D003F696B /* FunctionExecutableDump.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47DF1BCD9DC9004C5B45 /* FunctionPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A85D0255597D01FF60F7 /* FunctionPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E01BCD9DC9004C5B45 /* GCActivityCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = DDF7ABD211F60ED200108E36 /* GCActivityCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E11BCD9DC9004C5B45 /* GCAssertions.h in Headers */ = {isa = PBXBuildFile; fileRef = BCBE2CAD14E985AA000593AD /* GCAssertions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E21BCD9DC9004C5B45 /* GCAwareJITStubRoutine.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F766D2E15A8DCDD008F363E /* GCAwareJITStubRoutine.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E31BCD9DC9004C5B45 /* GCIncomingRefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66A817B6B53D00A7AE3F /* GCIncomingRefCounted.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E41BCD9DC9004C5B45 /* GCIncomingRefCountedInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66A917B6B53D00A7AE3F /* GCIncomingRefCountedInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E51BCD9DC9004C5B45 /* GCIncomingRefCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66AA17B6B53D00A7AE3F /* GCIncomingRefCountedSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E61BCD9DC9004C5B45 /* GCIncomingRefCountedSetInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66AB17B6B53D00A7AE3F /* GCIncomingRefCountedSetInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E71BCD9DC9004C5B45 /* GCThread.h in Headers */ = {isa = PBXBuildFile; fileRef = C2239D1616262BDD005AC5FD /* GCThread.h */; };
+		A3CA47E81BCD9DC9004C5B45 /* GCThreadSharedData.h in Headers */ = {isa = PBXBuildFile; fileRef = C21122DF15DD9AB300790E3A /* GCThreadSharedData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47E91BCD9DC9004C5B45 /* GenericTypedArrayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66B217B6B5AB00A7AE3F /* GenericTypedArrayView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47EA1BCD9DC9004C5B45 /* GenericTypedArrayViewInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66B317B6B5AB00A7AE3F /* GenericTypedArrayViewInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47EB1BCD9DC9004C5B45 /* GetByIdStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F93329614CA7DC10085F3C6 /* GetByIdStatus.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47EC1BCD9DC9004C5B45 /* GPRInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E53F17EA9F5900ABB217 /* GPRInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47ED1BCD9DC9004C5B45 /* Handle.h in Headers */ = {isa = PBXBuildFile; fileRef = 142E312B134FF0A600AFADB5 /* Handle.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47EE1BCD9DC9004C5B45 /* HandleBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = C28318FF16FE4B7D00157BFD /* HandleBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47EF1BCD9DC9004C5B45 /* HandleBlockInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = C283190116FE533E00157BFD /* HandleBlockInlines.h */; };
+		A3CA47F01BCD9DC9004C5B45 /* HandlerInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B83A814BCF55E00885B4F /* HandlerInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47F11BCD9DC9004C5B45 /* HandleSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 142E312D134FF0A600AFADB5 /* HandleSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47F21BCD9DC9004C5B45 /* HandleStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 142E312F134FF0A600AFADB5 /* HandleStack.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47F31BCD9DC9004C5B45 /* HandleTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 146FA5A81378F6B0003627A3 /* HandleTypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47F41BCD9DC9004C5B45 /* Heap.h in Headers */ = {isa = PBXBuildFile; fileRef = 14BA7A9613AADFF8005B7C2C /* Heap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47F51BCD9DC9004C5B45 /* HeapBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = C2C8D02F14A3CEFC00578E65 /* HeapBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47F61BCD9DC9004C5B45 /* HeapIterationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AD8932917E3868F00668276 /* HeapIterationScope.h */; };
+		A3CA47F71BCD9DC9004C5B45 /* HeapOperation.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A6F462517E959CE00C45C98 /* HeapOperation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47F81BCD9DC9004C5B45 /* HeapRootVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F97446138C853E00DA1C67 /* HeapRootVisitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47F91BCD9DC9004C5B45 /* HeapStatistics.h in Headers */ = {isa = PBXBuildFile; fileRef = C24D31E1161CD695002AA4DB /* HeapStatistics.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47FA1BCD9DC9004C5B45 /* FullBytecodeLiveness.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F666EBF183566F900D017F1 /* FullBytecodeLiveness.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47FB1BCD9DC9004C5B45 /* HeapTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = C2E526BC1590EF000054E48D /* HeapTimer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47FC1BCD9DC9004C5B45 /* HostCallReturnValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4680D114BBC5F800BFE272 /* HostCallReturnValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47FD1BCD9DC9004C5B45 /* Identifier.h in Headers */ = {isa = PBXBuildFile; fileRef = 933A349A038AE7C6008635CE /* Identifier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47FE1BCD9DC9004C5B45 /* IncrementalSweeper.h in Headers */ = {isa = PBXBuildFile; fileRef = C25F8BCC157544A900245B71 /* IncrementalSweeper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA47FF1BCD9DC9004C5B45 /* IndexingHeader.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38D15ED8E3800F167B2 /* IndexingHeader.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48001BCD9DC9004C5B45 /* IndexingHeaderInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38E15ED8E3800F167B2 /* IndexingHeaderInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48011BCD9DC9004C5B45 /* IndexingType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F38F15ED8E3800F167B2 /* IndexingType.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48021BCD9DC9004C5B45 /* InitializeLLVM.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCEFAAE1805CA6D00472CE4 /* InitializeLLVM.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48031BCD9DC9004C5B45 /* InitializeLLVMPOSIX.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCEFAC61805E75500472CE4 /* InitializeLLVMPOSIX.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48041BCD9DC9004C5B45 /* InitializeThreading.h in Headers */ = {isa = PBXBuildFile; fileRef = E178633F0D9BEC0000D74E75 /* InitializeThreading.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48051BCD9DC9004C5B45 /* InlineCallFrameSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E55417F0B71C00ABB217 /* InlineCallFrameSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48061BCD9DC9004C5B45 /* Instruction.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07930ED1D3AE00F1F681 /* Instruction.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48071BCD9DC9004C5B45 /* Int16Array.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF2C17ADB5F3005AB174 /* Int16Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48081BCD9DC9004C5B45 /* Int32Array.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF2D17ADB5F3005AB174 /* Int32Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48091BCD9DC9004C5B45 /* Int8Array.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF2B17ADB5F3005AB174 /* Int8Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA480A1BCD9DC9004C5B45 /* IntendedStructureChain.h in Headers */ = {isa = PBXBuildFile; fileRef = A78853F817972629001440E4 /* IntendedStructureChain.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA480B1BCD9DC9004C5B45 /* InternalFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = BC11667A0E199C05008066DD /* InternalFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA480C1BCD9DC9004C5B45 /* Interpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = 1429D77B0ED20D7300B89619 /* Interpreter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA480D1BCD9DC9004C5B45 /* Intrinsic.h in Headers */ = {isa = PBXBuildFile; fileRef = 86BF642A148DB2B5004DE36A /* Intrinsic.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA480E1BCD9DC9004C5B45 /* JavaScript.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CAA8B4A0D32C39A0041BCFF /* JavaScript.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA480F1BCD9DC9004C5B45 /* JavaScriptCore.h in Headers */ = {isa = PBXBuildFile; fileRef = 1CAA8B4B0D32C39A0041BCFF /* JavaScriptCore.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48101BCD9DC9004C5B45 /* JavaScriptCorePrefix.h in Headers */ = {isa = PBXBuildFile; fileRef = F5C290E60284F98E018635CA /* JavaScriptCorePrefix.h */; };
+		A3CA48111BCD9DC9004C5B45 /* JIT.h in Headers */ = {isa = PBXBuildFile; fileRef = 1429D92E0ED22D7000B89619 /* JIT.h */; };
+		A3CA48121BCD9DC9004C5B45 /* JITCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 86CCEFDD0F413F8900FD7F9E /* JITCode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48131BCD9DC9004C5B45 /* JITCompilationEffort.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0776BD14FF002800102332 /* JITCompilationEffort.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48141BCD9DC9004C5B45 /* JITDisassembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FAF7EFB165BA919000C8455 /* JITDisassembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48151BCD9DC9004C5B45 /* RemoteInspectorDebuggable.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BA15EF182345AF00A82E69 /* RemoteInspectorDebuggable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48161BCD9DC9004C5B45 /* JITExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F46808014BA572700BFE272 /* JITExceptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48171BCD9DC9004C5B45 /* DFGStrengthReductionPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC20CB41852E2C600C9E954 /* DFGStrengthReductionPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48181BCD9DC9004C5B45 /* JITInlineCacheGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB14E1D18124ACE009B6B4D /* JITInlineCacheGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48191BCD9DC9004C5B45 /* JITInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 86CC85A00EE79A4700288682 /* JITInlines.h */; };
+		A3CA481A1BCD9DC9004C5B45 /* JITOperations.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E54617EE274900ABB217 /* JITOperations.h */; };
+		A3CA481B1BCD9DC9004C5B45 /* JSSetIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A790DD6A182F499700588807 /* JSSetIterator.h */; };
+		A3CA481C1BCD9DC9004C5B45 /* JITOperationWrappers.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E54717EE274900ABB217 /* JITOperationWrappers.h */; };
+		A3CA481D1BCD9DC9004C5B45 /* JITStubRoutine.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F766D1C15A5028D008F363E /* JITStubRoutine.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA481E1BCD9DC9004C5B45 /* JITStubRoutineSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F766D2A15A8CC34008F363E /* JITStubRoutineSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA481F1BCD9DC9004C5B45 /* JITStubs.h in Headers */ = {isa = PBXBuildFile; fileRef = 14A6581A0F4E36F4000150FD /* JITStubs.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48201BCD9DC9004C5B45 /* JITStubsARM.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF6835A174343CC00A32E25 /* JITStubsARM.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48211BCD9DC9004C5B45 /* JITStubsARMv7.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF6835B174343CC00A32E25 /* JITStubsARMv7.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48221BCD9DC9004C5B45 /* JITStubsX86.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF6835D174343CC00A32E25 /* JITStubsX86.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48231BCD9DC9004C5B45 /* JITStubsX86_64.h in Headers */ = {isa = PBXBuildFile; fileRef = FEF6835C174343CC00A32E25 /* JITStubsX86_64.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48241BCD9DC9004C5B45 /* JITStubsX86Common.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A4AE0C17973B4D005612B1 /* JITStubsX86Common.h */; };
+		A3CA48251BCD9DC9004C5B45 /* JITThunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5EF91C16878F78003E5C25 /* JITThunks.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48261BCD9DC9004C5B45 /* JITToDFGDeferredCompilationCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC712E117CD878F008CC93C /* JITToDFGDeferredCompilationCallback.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48271BCD9DC9004C5B45 /* JITWriteBarrier.h in Headers */ = {isa = PBXBuildFile; fileRef = A76F54A213B28AAB00EF2BCE /* JITWriteBarrier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48281BCD9DC9004C5B45 /* JSActivation.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DA818E0D99FD2000B0A4FB /* JSActivation.h */; settings = {ATTRIBUTES = (); }; };
+		A3CA48291BCD9DC9004C5B45 /* JSAPIValueWrapper.h in Headers */ = {isa = PBXBuildFile; fileRef = BC0894D60FAFBA2D00001865 /* JSAPIValueWrapper.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA482A1BCD9DC9004C5B45 /* JSAPIWrapperObject.h in Headers */ = {isa = PBXBuildFile; fileRef = C2CF39C016E15A8100DD69BE /* JSAPIWrapperObject.h */; };
+		A3CA482B1BCD9DC9004C5B45 /* JSArgumentsIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A76140CC182982CB00750624 /* JSArgumentsIterator.h */; };
+		A3CA482C1BCD9DC9004C5B45 /* JSArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 938772E5038BFE19008635CE /* JSArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA482D1BCD9DC9004C5B45 /* JSArrayBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66B517B6B5AB00A7AE3F /* JSArrayBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA482E1BCD9DC9004C5B45 /* JSArrayBufferConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66B717B6B5AB00A7AE3F /* JSArrayBufferConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA482F1BCD9DC9004C5B45 /* JSArrayBufferPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66B917B6B5AB00A7AE3F /* JSArrayBufferPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48301BCD9DC9004C5B45 /* JSArrayBufferView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66BB17B6B5AB00A7AE3F /* JSArrayBufferView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48311BCD9DC9004C5B45 /* JSArrayBufferViewInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66BC17B6B5AB00A7AE3F /* JSArrayBufferViewInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48321BCD9DC9004C5B45 /* JSArrayIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A7BDAEC517F4EA1400F6140C /* JSArrayIterator.h */; };
+		A3CA48331BCD9DC9004C5B45 /* JSBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 142711380A460BBB0080EEEA /* JSBase.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48341BCD9DC9004C5B45 /* RecursiveAllocationScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 2AAD964918569417001F93BE /* RecursiveAllocationScope.h */; };
+		A3CA48351BCD9DC9004C5B45 /* JSBasePrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 140D17D60E8AD4A9000CD17D /* JSBasePrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48361BCD9DC9004C5B45 /* JSBoundFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 86FA9E90142BBB2E001773B7 /* JSBoundFunction.h */; };
+		A3CA48371BCD9DC9004C5B45 /* JSCallbackConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 1440F8AC0A508D200005F061 /* JSCallbackConstructor.h */; };
+		A3CA48381BCD9DC9004C5B45 /* JSCallbackFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 1440F88F0A508B100005F061 /* JSCallbackFunction.h */; };
+		A3CA48391BCD9DC9004C5B45 /* JSCallbackObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 14ABDF5D0A437FEF00ECCA01 /* JSCallbackObject.h */; };
+		A3CA483A1BCD9DC9004C5B45 /* JSCallbackObjectFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = A8E894310CD0602400367179 /* JSCallbackObjectFunctions.h */; };
+		A3CA483B1BCD9DC9004C5B45 /* JSCell.h in Headers */ = {isa = PBXBuildFile; fileRef = BC1167D80E19BCC9008066DD /* JSCell.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA483C1BCD9DC9004C5B45 /* JSCellInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F97496F1687ADE200A4FF6A /* JSCellInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA483D1BCD9DC9004C5B45 /* JSCJSValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 14ABB36E099C076400E2A24F /* JSCJSValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA483E1BCD9DC9004C5B45 /* JSCJSValueInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 865A30F0135007E100CDB49E /* JSCJSValueInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA483F1BCD9DC9004C5B45 /* JSClassRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 1440FCE10A51E46B0005F061 /* JSClassRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48401BCD9DC9004C5B45 /* JSContext.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E3C607167BAB87006D760A /* JSContext.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48411BCD9DC9004C5B45 /* JSContextInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E3C609167BAB87006D760A /* JSContextInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48421BCD9DC9004C5B45 /* JSContextRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 14BD5A2A0A3E91F600BAF59C /* JSContextRef.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48431BCD9DC9004C5B45 /* JSContextRefPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 148CD1D7108CF902008163C6 /* JSContextRefPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48441BCD9DC9004C5B45 /* JSCTestRunnerUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = A72028B51797601E0098028C /* JSCTestRunnerUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48451BCD9DC9004C5B45 /* JSDataView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66BE17B6B5AB00A7AE3F /* JSDataView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48461BCD9DC9004C5B45 /* JSDataViewPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C017B6B5AB00A7AE3F /* JSDataViewPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48471BCD9DC9004C5B45 /* JSDateMath.h in Headers */ = {isa = PBXBuildFile; fileRef = 9788FC231471AD0C0068CE2D /* JSDateMath.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48481BCD9DC9004C5B45 /* JSDestructibleObject.h in Headers */ = {isa = PBXBuildFile; fileRef = C2A7F687160432D400F76B98 /* JSDestructibleObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48491BCD9DC9004C5B45 /* JSExport.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E3C60A167BAB87006D760A /* JSExport.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA484A1BCD9DC9004C5B45 /* JSExportMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A7B4ACAE1484C9CE00B38A36 /* JSExportMacros.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA484B1BCD9DC9004C5B45 /* JSFloat32Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C117B6B5AB00A7AE3F /* JSFloat32Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA484C1BCD9DC9004C5B45 /* JSFloat64Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C217B6B5AB00A7AE3F /* JSFloat64Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA484D1BCD9DC9004C5B45 /* JSFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A85F0255597D01FF60F7 /* JSFunction.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA484E1BCD9DC9004C5B45 /* JSFunctionInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = A72028B91797603D0098028C /* JSFunctionInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA484F1BCD9DC9004C5B45 /* JSGenericTypedArrayView.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C317B6B5AB00A7AE3F /* JSGenericTypedArrayView.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48501BCD9DC9004C5B45 /* JSGenericTypedArrayViewConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C417B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48511BCD9DC9004C5B45 /* JSGenericTypedArrayViewConstructorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C517B6B5AB00A7AE3F /* JSGenericTypedArrayViewConstructorInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48521BCD9DC9004C5B45 /* JSGenericTypedArrayViewInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C617B6B5AB00A7AE3F /* JSGenericTypedArrayViewInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48531BCD9DC9004C5B45 /* JSGenericTypedArrayViewPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C717B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48541BCD9DC9004C5B45 /* JSGenericTypedArrayViewPrototypeInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C817B6B5AB00A7AE3F /* JSGenericTypedArrayViewPrototypeInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48551BCD9DC9004C5B45 /* JSGlobalObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A8E894330CD0603F00367179 /* JSGlobalObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48561BCD9DC9004C5B45 /* JSGlobalObjectFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = BC756FC70E2031B200DE7D12 /* JSGlobalObjectFunctions.h */; };
+		A3CA48571BCD9DC9004C5B45 /* JSInt16Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66CA17B6B5AB00A7AE3F /* JSInt16Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48581BCD9DC9004C5B45 /* JSInt32Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66CB17B6B5AB00A7AE3F /* JSInt32Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48591BCD9DC9004C5B45 /* JSInt8Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66C917B6B5AB00A7AE3F /* JSInt8Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA485A1BCD9DC9004C5B45 /* JSInterfaceJIT.h in Headers */ = {isa = PBXBuildFile; fileRef = A76C51741182748D00715B05 /* JSInterfaceJIT.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA485B1BCD9DC9004C5B45 /* JSLock.h in Headers */ = {isa = PBXBuildFile; fileRef = 65EA4C9A092AF9E20093D800 /* JSLock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA485C1BCD9DC9004C5B45 /* JSManagedValue.h in Headers */ = {isa = PBXBuildFile; fileRef = C25D709A16DE99F400FCA6BC /* JSManagedValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA485D1BCD9DC9004C5B45 /* JSMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A700874017CBE8EB00C3E643 /* JSMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA485E1BCD9DC9004C5B45 /* JSNameScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 14874AE015EBDE4A002E3587 /* JSNameScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA485F1BCD9DC9004C5B45 /* JSObject.h in Headers */ = {isa = PBXBuildFile; fileRef = BC22A3990E16E14800AF21C8 /* JSObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48601BCD9DC9004C5B45 /* JSObjectRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 1482B7E10A43076000517CFC /* JSObjectRef.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48611BCD9DC9004C5B45 /* JSObjectRefPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A79EDB0811531CD60019E912 /* JSObjectRefPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48621BCD9DC9004C5B45 /* JSONObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A7F9935D0FD7325100A0B2D0 /* JSONObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48631BCD9DC9004C5B45 /* JSONObject.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = BC87CDB810712ACA000614CF /* JSONObject.lut.h */; };
+		A3CA48641BCD9DC9004C5B45 /* JSProfilerPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 952C63AC0E4777D600C13936 /* JSProfilerPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48651BCD9DC9004C5B45 /* JSPromise.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C184E1917BEDBD3007CB63A /* JSPromise.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48661BCD9DC9004C5B45 /* JSPromiseConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C184E2117BEE240007CB63A /* JSPromiseConstructor.h */; };
+		A3CA48671BCD9DC9004C5B45 /* JSPromisePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C184E1D17BEE22E007CB63A /* JSPromisePrototype.h */; };
+		A3CA48681BCD9DC9004C5B45 /* JSMapIterator.h in Headers */ = {isa = PBXBuildFile; fileRef = A74DEF90182D991400522C22 /* JSMapIterator.h */; };
+		A3CA48691BCD9DC9004C5B45 /* JSProxy.h in Headers */ = {isa = PBXBuildFile; fileRef = 862553CF16136AA5009F17D0 /* JSProxy.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA486A1BCD9DC9004C5B45 /* JSRetainPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 95C18D3E0C90E7EF00E72F73 /* JSRetainPtr.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA486B1BCD9DC9004C5B45 /* JSScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 14874AE215EBDE4A002E3587 /* JSScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA486C1BCD9DC9004C5B45 /* JSScriptRefPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A7C0C4AB167C08CD0017011D /* JSScriptRefPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA486D1BCD9DC9004C5B45 /* JSSegmentedVariableObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F919D0F157F3327004A4E7D /* JSSegmentedVariableObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA486E1BCD9DC9004C5B45 /* JSSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A7299D9C17D12837005F5FF9 /* JSSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA486F1BCD9DC9004C5B45 /* JSStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D792640DAA03FB001A9F05 /* JSStack.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48701BCD9DC9004C5B45 /* JSStackInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = A7C1EAEB17987AB600299DB2 /* JSStackInlines.h */; };
+		A3CA48711BCD9DC9004C5B45 /* JSString.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A8620255597D01FF60F7 /* JSString.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48721BCD9DC9004C5B45 /* JSStringBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E85538111B9968001AF51E /* JSStringBuilder.h */; };
+		A3CA48731BCD9DC9004C5B45 /* JSStringJoiner.h in Headers */ = {isa = PBXBuildFile; fileRef = 2600B5A5152BAAA70091EE5F /* JSStringJoiner.h */; };
+		A3CA48741BCD9DC9004C5B45 /* JSStringRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 1482B74B0A43032800517CFC /* JSStringRef.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48751BCD9DC9004C5B45 /* JSStringRefCF.h in Headers */ = {isa = PBXBuildFile; fileRef = 146AAB2A0B66A84900E55F16 /* JSStringRefCF.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48761BCD9DC9004C5B45 /* JSStringRefPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A28D4A7177B71C80007FA3C /* JSStringRefPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48771BCD9DC9004C5B45 /* JSSymbolTableObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F919D0A157EE09D004A4E7D /* JSSymbolTableObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48781BCD9DC9004C5B45 /* JSType.h in Headers */ = {isa = PBXBuildFile; fileRef = 14ABB454099C2A0F00E2A24F /* JSType.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48791BCD9DC9004C5B45 /* JSTypedArrayConstructors.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66CD17B6B5AB00A7AE3F /* JSTypedArrayConstructors.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA487A1BCD9DC9004C5B45 /* JSTypedArrayPrototypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66CF17B6B5AB00A7AE3F /* JSTypedArrayPrototypes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA487B1BCD9DC9004C5B45 /* JSTypedArrays.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66D117B6B5AB00A7AE3F /* JSTypedArrays.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA487C1BCD9DC9004C5B45 /* JSTypeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 6507D2970E871E4A00D7D896 /* JSTypeInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA487D1BCD9DC9004C5B45 /* JSUint16Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66D417B6B5AB00A7AE3F /* JSUint16Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA487E1BCD9DC9004C5B45 /* JSUint32Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66D517B6B5AB00A7AE3F /* JSUint32Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA487F1BCD9DC9004C5B45 /* JSUint8Array.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66D217B6B5AB00A7AE3F /* JSUint8Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48801BCD9DC9004C5B45 /* JSUint8ClampedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66D317B6B5AB00A7AE3F /* JSUint8ClampedArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48811BCD9DC9004C5B45 /* JSValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E3C606167BAB87006D760A /* JSValue.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48821BCD9DC9004C5B45 /* JSValueInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E3C60E167BAB87006D760A /* JSValueInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48831BCD9DC9004C5B45 /* JSValueRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 1482B6EA0A4300B300517CFC /* JSValueRef.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48841BCD9DC9004C5B45 /* JSVariableObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F252560D08DD8D004ECFFF /* JSVariableObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48851BCD9DC9004C5B45 /* JSVirtualMachine.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E3C60F167BAB87006D760A /* JSVirtualMachine.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA48861BCD9DC9004C5B45 /* JSVirtualMachineInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E3C611167BAB87006D760A /* JSVirtualMachineInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48871BCD9DC9004C5B45 /* JSWeakMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A7CA3AE217DA41AE006538AF /* JSWeakMap.h */; };
+		A3CA48881BCD9DC9004C5B45 /* JSWeakObjectMapRefInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = A7482E37116A697B003B0712 /* JSWeakObjectMapRefInternal.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48891BCD9DC9004C5B45 /* JSWeakObjectMapRefPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = A7482B791166CDEA003B0712 /* JSWeakObjectMapRefPrivate.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA488A1BCD9DC9004C5B45 /* JSWithScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 1442566015EDE98D0066A49B /* JSWithScope.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA488B1BCD9DC9004C5B45 /* JSWrapperMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 86E3C60C167BAB87006D760A /* JSWrapperMap.h */; };
+		A3CA488C1BCD9DC9004C5B45 /* JSWrapperObject.h in Headers */ = {isa = PBXBuildFile; fileRef = 65C7A1720A8EAACB00FA37EA /* JSWrapperObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA488D1BCD9DC9004C5B45 /* JumpTable.h in Headers */ = {isa = PBXBuildFile; fileRef = BCFD8C910EEB2EE700283848 /* JumpTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA488E1BCD9DC9004C5B45 /* MapIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A74DEF8E182D991400522C22 /* MapIteratorPrototype.h */; };
+		A3CA488F1BCD9DC9004C5B45 /* KeywordLookup.h in Headers */ = {isa = PBXBuildFile; fileRef = A7C225CD1399849C00FF1662 /* KeywordLookup.h */; };
+		A3CA48901BCD9DC9004C5B45 /* Label.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07270ED1CE6900F1F681 /* Label.h */; };
+		A3CA48911BCD9DC9004C5B45 /* LabelScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 960097A50EBABB58007A7297 /* LabelScope.h */; };
+		A3CA48921BCD9DC9004C5B45 /* LazyOperandValueProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB5467614F59AD1002C2989 /* LazyOperandValueProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48931BCD9DC9004C5B45 /* LegacyProfiler.h in Headers */ = {isa = PBXBuildFile; fileRef = 95AB832F0DA42CAD00BC83F3 /* LegacyProfiler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48941BCD9DC9004C5B45 /* Lexer.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A8660255597D01FF60F7 /* Lexer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48951BCD9DC9004C5B45 /* Lexer.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = BC18C52D0E16FCE100B34460 /* Lexer.lut.h */; };
+		A3CA48961BCD9DC9004C5B45 /* LineInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B83AC14BCF60200885B4F /* LineInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48971BCD9DC9004C5B45 /* LinkBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D3B3C110159D7F002865E7 /* LinkBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48981BCD9DC9004C5B45 /* ListableHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F431736146BAC65007E3890 /* ListableHandler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48991BCD9DC9004C5B45 /* LiteralParser.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E2EA690FB460CF00601F06 /* LiteralParser.h */; };
+		A3CA489A1BCD9DC9004C5B45 /* LLIntCallLinkInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0FC45814BD15F100B81154 /* LLIntCallLinkInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA489B1BCD9DC9004C5B45 /* LLIntCLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = FE20CE9C15F04A9500DF3430 /* LLIntCLoop.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA489C1BCD9DC9004C5B45 /* LLIntCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4680C514BBB16900BFE272 /* LLIntCommon.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA489D1BCD9DC9004C5B45 /* LLIntData.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4680CF14BBB3D100BFE272 /* LLIntData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA489E1BCD9DC9004C5B45 /* LLIntEntrypoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F38B01017CF077F00B144D3 /* LLIntEntrypoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA489F1BCD9DC9004C5B45 /* LLIntExceptions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F46809E14BA7F8200BFE272 /* LLIntExceptions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A01BCD9DC9004C5B45 /* LLIntOfflineAsmConfig.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4680C614BBB16900BFE272 /* LLIntOfflineAsmConfig.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A11BCD9DC9004C5B45 /* LLIntOpcode.h in Headers */ = {isa = PBXBuildFile; fileRef = FED287B115EC9A5700DA8161 /* LLIntOpcode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A21BCD9DC9004C5B45 /* JSPromiseDeferred.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C008CD9187124BB00955C24 /* JSPromiseDeferred.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A31BCD9DC9004C5B45 /* LLIntSlowPaths.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4680A014BA7F8200BFE272 /* LLIntSlowPaths.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A41BCD9DC9004C5B45 /* LLIntThunks.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0B839814BCF45A00885B4F /* LLIntThunks.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A51BCD9DC9004C5B45 /* LLVMAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCEFAC81805E75500472CE4 /* LLVMAPI.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A61BCD9DC9004C5B45 /* LLVMAPIFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCEFAC91805E75500472CE4 /* LLVMAPIFunctions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A71BCD9DC9004C5B45 /* LLVMDisassembler.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E5AB341799E4B200D2833D /* LLVMDisassembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A81BCD9DC9004C5B45 /* LLVMHeaders.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCEFAD21805EDCC00472CE4 /* LLVMHeaders.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48A91BCD9DC9004C5B45 /* Local.h in Headers */ = {isa = PBXBuildFile; fileRef = 142E3130134FF0A600AFADB5 /* Local.h */; };
+		A3CA48AA1BCD9DC9004C5B45 /* LocalScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 142E3131134FF0A600AFADB5 /* LocalScope.h */; };
+		A3CA48AB1BCD9DC9004C5B45 /* Lookup.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A8690255597D01FF60F7 /* Lookup.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48AC1BCD9DC9004C5B45 /* LowLevelInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4680C814BBB16900BFE272 /* LowLevelInterpreter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48AD1BCD9DC9004C5B45 /* MachineStackMarker.h in Headers */ = {isa = PBXBuildFile; fileRef = 14B7234012D7D0DA003BD5ED /* MachineStackMarker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48AE1BCD9DC9004C5B45 /* MacroAssembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C36EE90EE1289D00B3DF59 /* MacroAssembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48AF1BCD9DC9004C5B45 /* MacroAssemblerARM.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D3B2C210156BDE002865E7 /* MacroAssemblerARM.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B01BCD9DC9004C5B45 /* MacroAssemblerARMv7.h in Headers */ = {isa = PBXBuildFile; fileRef = 86ADD1440FDDEA980006EEC2 /* MacroAssemblerARMv7.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B11BCD9DC9004C5B45 /* MacroAssemblerCodeRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 863B23DF0FC60E6200703AA4 /* MacroAssemblerCodeRef.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B21BCD9DC9004C5B45 /* MacroAssemblerMIPS.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C568DE11A213EE0007F7F0 /* MacroAssemblerMIPS.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B31BCD9DC9004C5B45 /* MacroAssemblerSH4.h in Headers */ = {isa = PBXBuildFile; fileRef = 86AE64A6135E5E1C00963012 /* MacroAssemblerSH4.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B41BCD9DC9004C5B45 /* MacroAssemblerX86.h in Headers */ = {isa = PBXBuildFile; fileRef = 860161E00F3A83C100F84710 /* MacroAssemblerX86.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B51BCD9DC9004C5B45 /* MacroAssemblerX86_64.h in Headers */ = {isa = PBXBuildFile; fileRef = 860161E10F3A83C100F84710 /* MacroAssemblerX86_64.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B61BCD9DC9004C5B45 /* MacroAssemblerX86Common.h in Headers */ = {isa = PBXBuildFile; fileRef = 860161E20F3A83C100F84710 /* MacroAssemblerX86Common.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B71BCD9DC9004C5B45 /* MapConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A700873817CBE85300C3E643 /* MapConstructor.h */; };
+		A3CA48B81BCD9DC9004C5B45 /* MapData.h in Headers */ = {isa = PBXBuildFile; fileRef = A78507D517CBC6FD0011F6E7 /* MapData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48B91BCD9DC9004C5B45 /* MapPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A700873C17CBE8D300C3E643 /* MapPrototype.h */; };
+		A3CA48BA1BCD9DC9004C5B45 /* MarkedAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = C2B916C114DA014E00CBAC86 /* MarkedAllocator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48BB1BCD9DC9004C5B45 /* MarkedBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 142D6F0713539A2800B02E86 /* MarkedBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48BC1BCD9DC9004C5B45 /* MarkedBlockSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 141448CA13A176EC00F5BA1A /* MarkedBlockSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48BD1BCD9DC9004C5B45 /* MarkedSpace.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D2F3D9139F4BE200491031 /* MarkedSpace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48BE1BCD9DC9004C5B45 /* MarkStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 142D6F0F13539A4100B02E86 /* MarkStack.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48BF1BCD9DC9004C5B45 /* MarkStackInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = C21122E015DD9AB300790E3A /* MarkStackInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48C01BCD9DC9004C5B45 /* InspectorFrontendChannel.h in Headers */ = {isa = PBXBuildFile; fileRef = A5945594182479EB00CC3843 /* InspectorFrontendChannel.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48C11BCD9DC9004C5B45 /* MatchResult.h in Headers */ = {isa = PBXBuildFile; fileRef = 8612E4CB1522918400C836BE /* MatchResult.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48C21BCD9DC9004C5B45 /* MathObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A86B0255597D01FF60F7 /* MathObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48C31BCD9DC9004C5B45 /* MemoryStatistics.h in Headers */ = {isa = PBXBuildFile; fileRef = 90213E3C123A40C200D422F3 /* MemoryStatistics.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48C41BCD9DC9004C5B45 /* MethodOfGettingAValueProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB5467A14F5C7D4002C2989 /* MethodOfGettingAValueProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48C51BCD9DC9004C5B45 /* MIPSAssembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 86C568DF11A213EE0007F7F0 /* MIPSAssembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48C61BCD9DC9004C5B45 /* NameConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EBF2FA1560F036008E9222 /* NameConstructor.h */; };
+		A3CA48C71BCD9DC9004C5B45 /* SetIteratorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A790DD68182F499700588807 /* SetIteratorPrototype.h */; };
+		A3CA48C81BCD9DC9004C5B45 /* NameInstance.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EBF2FC1560F036008E9222 /* NameInstance.h */; };
+		A3CA48C91BCD9DC9004C5B45 /* NamePrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = 86EBF2FE1560F036008E9222 /* NamePrototype.h */; };
+		A3CA48CA1BCD9DC9004C5B45 /* NativeErrorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E9090E1839DB000F9297 /* NativeErrorConstructor.h */; };
+		A3CA48CB1BCD9DC9004C5B45 /* NativeErrorPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BC02E90B0E1839DB000F9297 /* NativeErrorPrototype.h */; };
+		A3CA48CC1BCD9DC9004C5B45 /* NodeConstructors.h in Headers */ = {isa = PBXBuildFile; fileRef = 930DAD030FB1EB1A0082D205 /* NodeConstructors.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48CD1BCD9DC9004C5B45 /* NodeInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = 7EFF00630EC05A9A00AA7C93 /* NodeInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48CE1BCD9DC9004C5B45 /* Nodes.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A86E0255597D01FF60F7 /* Nodes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48CF1BCD9DC9004C5B45 /* NumberConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2680C30E16D4E900A06E92 /* NumberConstructor.h */; };
+		A3CA48D01BCD9DC9004C5B45 /* NumberConstructor.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2680E60E16D52300A06E92 /* NumberConstructor.lut.h */; };
+		A3CA48D11BCD9DC9004C5B45 /* NumberObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A8710255597D01FF60F7 /* NumberObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48D21BCD9DC9004C5B45 /* NumberPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2680C50E16D4E900A06E92 /* NumberPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48D31BCD9DC9004C5B45 /* NumericStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = 142D3938103E4560007DCB52 /* NumericStrings.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48D41BCD9DC9004C5B45 /* ObjCCallbackFunction.h in Headers */ = {isa = PBXBuildFile; fileRef = 86F3EEB9168CCF750077B92A /* ObjCCallbackFunction.h */; };
+		A3CA48D51BCD9DC9004C5B45 /* ObjcRuntimeExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 86F3EEB616855A5B0077B92A /* ObjcRuntimeExtras.h */; };
+		A3CA48D61BCD9DC9004C5B45 /* ObjectAllocationProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 14CA958C16AB50FA00938A06 /* ObjectAllocationProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48D71BCD9DC9004C5B45 /* ObjectConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2680C70E16D4E900A06E92 /* ObjectConstructor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48D81BCD9DC9004C5B45 /* ObjectPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BC2680C90E16D4E900A06E92 /* ObjectPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48D91BCD9DC9004C5B45 /* OpaqueJSString.h in Headers */ = {isa = PBXBuildFile; fileRef = E124A8F50E555775003091F1 /* OpaqueJSString.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48DA1BCD9DC9004C5B45 /* Opcode.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07950ED1D3AE00F1F681 /* Opcode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48DB1BCD9DC9004C5B45 /* Operands.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2BDC2B151FDE8B00CD8910 /* Operands.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48DC1BCD9DC9004C5B45 /* ARM64Assembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 8640923B156EED3B00566CB2 /* ARM64Assembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48DD1BCD9DC9004C5B45 /* OperandsInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = A70447E917A0BD4600F5898E /* OperandsInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48DE1BCD9DC9004C5B45 /* Operations.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A8780255597D01FF60F7 /* Operations.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48DF1BCD9DC9004C5B45 /* Options.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE228EB1436AB2300196C48 /* Options.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E01BCD9DC9004C5B45 /* Parser.h in Headers */ = {isa = PBXBuildFile; fileRef = 93F0B3AA09BB4DC00068FCE3 /* Parser.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E11BCD9DC9004C5B45 /* ParserArena.h in Headers */ = {isa = PBXBuildFile; fileRef = 93052C330FB792190048FDC3 /* ParserArena.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E21BCD9DC9004C5B45 /* ParserError.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCCAE4316D0CF6E00D0C65B /* ParserError.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E31BCD9DC9004C5B45 /* ParserModes.h in Headers */ = {isa = PBXBuildFile; fileRef = A77F18241641925400640A47 /* ParserModes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E41BCD9DC9004C5B45 /* ParserTokens.h in Headers */ = {isa = PBXBuildFile; fileRef = 65303D631447B9E100D3F904 /* ParserTokens.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E51BCD9DC9004C5B45 /* PolymorphicAccessStructureList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F34B14B16D43E0C001CDA5A /* PolymorphicAccessStructureList.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E61BCD9DC9004C5B45 /* PolymorphicPutByIdList.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9FC8C014E1B5FB00D52AE0 /* PolymorphicPutByIdList.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E71BCD9DC9004C5B45 /* PreciseJumpTargets.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F98205E16BFE37F00240D02 /* PreciseJumpTargets.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E81BCD9DC9004C5B45 /* PrivateName.h in Headers */ = {isa = PBXBuildFile; fileRef = 868916A9155F285400CB2B9A /* PrivateName.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48E91BCD9DC9004C5B45 /* Profile.h in Headers */ = {isa = PBXBuildFile; fileRef = 95742F640DD11F5A000917FB /* Profile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48EA1BCD9DC9004C5B45 /* ProfiledCodeBlockJettisoningWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC97F32182020D7002C9B26 /* ProfiledCodeBlockJettisoningWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48EB1BCD9DC9004C5B45 /* ProfileGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 95CD45750E1C4FDD0085358E /* ProfileGenerator.h */; settings = {ATTRIBUTES = (); }; };
+		A3CA48EC1BCD9DC9004C5B45 /* ProfileNode.h in Headers */ = {isa = PBXBuildFile; fileRef = 95AB83550DA43B4400BC83F3 /* ProfileNode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48ED1BCD9DC9004C5B45 /* ProfilerBytecode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF72993166AD347000F5BA3 /* ProfilerBytecode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48EE1BCD9DC9004C5B45 /* BytecodeLivenessAnalysisInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F666EBE183566F900D017F1 /* BytecodeLivenessAnalysisInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48EF1BCD9DC9004C5B45 /* ProfilerBytecodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF72995166AD347000F5BA3 /* ProfilerBytecodes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F01BCD9DC9004C5B45 /* ProfilerBytecodeSequence.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F13912516771C30009CCB07 /* ProfilerBytecodeSequence.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F11BCD9DC9004C5B45 /* ProfilerCompilation.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF72997166AD347000F5BA3 /* ProfilerCompilation.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F21BCD9DC9004C5B45 /* ProfilerCompilationKind.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF72999166AD347000F5BA3 /* ProfilerCompilationKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F31BCD9DC9004C5B45 /* ProfilerCompiledBytecode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF7299B166AD347000F5BA3 /* ProfilerCompiledBytecode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F41BCD9DC9004C5B45 /* ProfilerDatabase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF7299D166AD347000F5BA3 /* ProfilerDatabase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F51BCD9DC9004C5B45 /* ProfilerExecutionCounter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF7299E166AD347000F5BA3 /* ProfilerExecutionCounter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F61BCD9DC9004C5B45 /* ProfilerOrigin.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF729A0166AD347000F5BA3 /* ProfilerOrigin.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F71BCD9DC9004C5B45 /* ProfilerOriginStack.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF729A2166AD347000F5BA3 /* ProfilerOriginStack.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F81BCD9DC9004C5B45 /* ProfilerOSRExit.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB105881675482E00F8AB6E /* ProfilerOSRExit.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48F91BCD9DC9004C5B45 /* ProfilerOSRExitSite.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB1058A1675482E00F8AB6E /* ProfilerOSRExitSite.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48FA1BCD9DC9004C5B45 /* ProfilerProfiledBytecodes.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F13912716771C30009CCB07 /* ProfilerProfiledBytecodes.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48FB1BCD9DC9004C5B45 /* PropertyDescriptor.h in Headers */ = {isa = PBXBuildFile; fileRef = A7FB604B103F5EAB0017A286 /* PropertyDescriptor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48FC1BCD9DC9004C5B45 /* PropertyMapHashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = BC95437C0EBA70FD0072B6D3 /* PropertyMapHashTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48FD1BCD9DC9004C5B45 /* PropertyName.h in Headers */ = {isa = PBXBuildFile; fileRef = 86158AB2155C8B3F00B45C9C /* PropertyName.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48FE1BCD9DC9004C5B45 /* PropertyNameArray.h in Headers */ = {isa = PBXBuildFile; fileRef = 65400C100A69BAF200509887 /* PropertyNameArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA48FF1BCD9DC9004C5B45 /* PropertyOffset.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF7168A15A3B231008F5DAA /* PropertyOffset.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49001BCD9DC9004C5B45 /* PropertySlot.h in Headers */ = {isa = PBXBuildFile; fileRef = 65621E6C089E859700760F35 /* PropertySlot.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49011BCD9DC9004C5B45 /* PropertyStorage.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F39015ED8E3800F167B2 /* PropertyStorage.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49021BCD9DC9004C5B45 /* Protect.h in Headers */ = {isa = PBXBuildFile; fileRef = 65C02FBB0637462A003E7EE6 /* Protect.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49031BCD9DC9004C5B45 /* PrototypeMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 14D844A316AA2C7000A65AF0 /* PrototypeMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49041BCD9DC9004C5B45 /* PutByIdStatus.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F93329A14CA7DC10085F3C6 /* PutByIdStatus.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49051BCD9DC9004C5B45 /* PutDirectIndexMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0CD4C015F1A6040032F1C0 /* PutDirectIndexMode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49061BCD9DC9004C5B45 /* Microtask.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C008CE5187631B600955C24 /* Microtask.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49071BCD9DC9004C5B45 /* PutKind.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9FC8C114E1B5FB00D52AE0 /* PutKind.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49081BCD9DC9004C5B45 /* PutPropertySlot.h in Headers */ = {isa = PBXBuildFile; fileRef = 147B84620E6DE6B1004775A4 /* PutPropertySlot.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49091BCD9DC9004C5B45 /* InspectorBackendDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = A593CF7B1840360300BFCE27 /* InspectorBackendDispatcher.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA490A1BCD9DC9004C5B45 /* ReduceWhitespace.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF60AC016740F8100029779 /* ReduceWhitespace.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA490B1BCD9DC9004C5B45 /* RegExp.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A87E0255597D01FF60F7 /* RegExp.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA490C1BCD9DC9004C5B45 /* RegExpCache.h in Headers */ = {isa = PBXBuildFile; fileRef = A1712B3E11C7B228007A5315 /* RegExpCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA490D1BCD9DC9004C5B45 /* RegExpConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD202BE0E1706A7002C7E82 /* RegExpConstructor.h */; };
+		A3CA490E1BCD9DC9004C5B45 /* JSPromiseReaction.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C008CDD1871258D00955C24 /* JSPromiseReaction.h */; };
+		A3CA490F1BCD9DC9004C5B45 /* RegExpConstructor.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD202D50E170708002C7E82 /* RegExpConstructor.lut.h */; };
+		A3CA49101BCD9DC9004C5B45 /* RegExpKey.h in Headers */ = {isa = PBXBuildFile; fileRef = A1712B4011C7B235007A5315 /* RegExpKey.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49111BCD9DC9004C5B45 /* StackAlignment.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F3AC751183EA1040032029F /* StackAlignment.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49121BCD9DC9004C5B45 /* RegExpObject.h in Headers */ = {isa = PBXBuildFile; fileRef = F692A87C0255597D01FF60F7 /* RegExpObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49131BCD9DC9004C5B45 /* RegExpObject.lut.h in Headers */ = {isa = PBXBuildFile; fileRef = BC18C52B0E16FCD200B34460 /* RegExpObject.lut.h */; };
+		A3CA49141BCD9DC9004C5B45 /* RegExpPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BCD202C00E1706A7002C7E82 /* RegExpPrototype.h */; };
+		A3CA49151BCD9DC9004C5B45 /* Region.h in Headers */ = {isa = PBXBuildFile; fileRef = C20B25981706536200C21F4E /* Region.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49161BCD9DC9004C5B45 /* Register.h in Headers */ = {isa = PBXBuildFile; fileRef = 149B24FF0D8AF6D1009CB8C7 /* Register.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49171BCD9DC9004C5B45 /* RegisterID.h in Headers */ = {isa = PBXBuildFile; fileRef = 969A07280ED1CE6900F1F681 /* RegisterID.h */; };
+		A3CA49181BCD9DC9004C5B45 /* RegisterSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC314101814559100033232 /* RegisterSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49191BCD9DC9004C5B45 /* Reject.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F39115ED8E3800F167B2 /* Reject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA491A1BCD9DC9004C5B45 /* Repatch.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E54A17EE274900ABB217 /* Repatch.h */; };
+		A3CA491B1BCD9DC9004C5B45 /* RepatchBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 86D3B3C210159D7F002865E7 /* RepatchBuffer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA491C1BCD9DC9004C5B45 /* ResultType.h in Headers */ = {isa = PBXBuildFile; fileRef = 869EBCB60E8C6D4A008722CC /* ResultType.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA491D1BCD9DC9004C5B45 /* SamplingCounter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F77008E1402FDD60078EB39 /* SamplingCounter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA491E1BCD9DC9004C5B45 /* SamplingTool.h in Headers */ = {isa = PBXBuildFile; fileRef = 1429D8840ED21C3D00B89619 /* SamplingTool.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA491F1BCD9DC9004C5B45 /* ScratchRegisterAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F24E54B17EE274900ABB217 /* ScratchRegisterAllocator.h */; };
+		A3CA49201BCD9DC9004C5B45 /* DelayedReleaseScope.h in Headers */ = {isa = PBXBuildFile; fileRef = 2A2825CF18341F2D0087FBA9 /* DelayedReleaseScope.h */; };
+		A3CA49211BCD9DC9004C5B45 /* SetConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A7299DA417D12858005F5FF9 /* SetConstructor.h */; };
+		A3CA49221BCD9DC9004C5B45 /* SetPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A7299DA017D12848005F5FF9 /* SetPrototype.h */; };
+		A3CA49231BCD9DC9004C5B45 /* SH4Assembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 86AE64A7135E5E1C00963012 /* SH4Assembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49241BCD9DC9004C5B45 /* SimpleTypedArrayController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66D717B6B5AB00A7AE3F /* SimpleTypedArrayController.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49251BCD9DC9004C5B45 /* JSPromiseFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C008CD1186F8A9300955C24 /* JSPromiseFunctions.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49261BCD9DC9004C5B45 /* SetIteratorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A790DD66182F499700588807 /* SetIteratorConstructor.h */; };
+		A3CA49271BCD9DC9004C5B45 /* SlotVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = 14BA78F013AAB88F005B7C2C /* SlotVisitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49281BCD9DC9004C5B45 /* SlotVisitorInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FCB408515C0A3C30048932B /* SlotVisitorInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49291BCD9DC9004C5B45 /* SlowPathCall.h in Headers */ = {isa = PBXBuildFile; fileRef = A709F2EF17A0AC0400512E98 /* SlowPathCall.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA492A1BCD9DC9004C5B45 /* SmallStrings.h in Headers */ = {isa = PBXBuildFile; fileRef = 93303FEA0E6A72C000786E6A /* SmallStrings.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA492B1BCD9DC9004C5B45 /* SourceCode.h in Headers */ = {isa = PBXBuildFile; fileRef = 65E866EE0DD59AFA00A2B2A1 /* SourceCode.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA492C1BCD9DC9004C5B45 /* SourceProvider.h in Headers */ = {isa = PBXBuildFile; fileRef = 65E866ED0DD59AFA00A2B2A1 /* SourceProvider.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA492D1BCD9DC9004C5B45 /* SourceProviderCache.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC15112EF272200184A1F /* SourceProviderCache.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA492E1BCD9DC9004C5B45 /* SourceProviderCacheItem.h in Headers */ = {isa = PBXBuildFile; fileRef = E49DC14912EF261A00184A1F /* SourceProviderCacheItem.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA492F1BCD9DC9004C5B45 /* SparseArrayValueMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB7F39215ED8E3800F167B2 /* SparseArrayValueMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49301BCD9DC9004C5B45 /* SpecializedThunkJIT.h in Headers */ = {isa = PBXBuildFile; fileRef = A7386551118697B400540279 /* SpecializedThunkJIT.h */; };
+		A3CA49311BCD9DC9004C5B45 /* SpecialPointer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5541B01613C1FB00CE3E25 /* SpecialPointer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49321BCD9DC9004C5B45 /* SpeculatedType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD82E4F141DAEA100179C94 /* SpeculatedType.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49331BCD9DC9004C5B45 /* StackVisitor.h in Headers */ = {isa = PBXBuildFile; fileRef = A7C1EAED17987AB600299DB2 /* StackVisitor.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49341BCD9DC9004C5B45 /* StaticPropertyAnalysis.h in Headers */ = {isa = PBXBuildFile; fileRef = 14DF04D916B3996D0016A513 /* StaticPropertyAnalysis.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49351BCD9DC9004C5B45 /* ScriptObject.h in Headers */ = {isa = PBXBuildFile; fileRef = A54CF2F8184EAEDA00237F19 /* ScriptObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49361BCD9DC9004C5B45 /* StaticPropertyAnalyzer.h in Headers */ = {isa = PBXBuildFile; fileRef = 14CA958A16AB50DE00938A06 /* StaticPropertyAnalyzer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49371BCD9DC9004C5B45 /* StrictEvalActivation.h in Headers */ = {isa = PBXBuildFile; fileRef = A730B6101250068F009D25B1 /* StrictEvalActivation.h */; };
+		A3CA49381BCD9DC9004C5B45 /* StringConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = BC18C3C10E16EE3300B34460 /* StringConstructor.h */; };
+		A3CA49391BCD9DC9004C5B45 /* StringObject.h in Headers */ = {isa = PBXBuildFile; fileRef = BC18C3C30E16EE3300B34460 /* StringObject.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA493A1BCD9DC9004C5B45 /* StringPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = BC18C3C60E16EE3300B34460 /* StringPrototype.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA493B1BCD9DC9004C5B45 /* Strong.h in Headers */ = {isa = PBXBuildFile; fileRef = 142E3132134FF0A600AFADB5 /* Strong.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA493C1BCD9DC9004C5B45 /* StrongInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 145722851437E140005FDE26 /* StrongInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA493D1BCD9DC9004C5B45 /* Structure.h in Headers */ = {isa = PBXBuildFile; fileRef = BCDE3AB10E6C82CF001453A7 /* Structure.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA493E1BCD9DC9004C5B45 /* StructureChain.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E4EE7080EBB7963005934AA /* StructureChain.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA493F1BCD9DC9004C5B45 /* StructureInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD2C92316D01EE900C7803F /* StructureInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49401BCD9DC9004C5B45 /* StructureRareData.h in Headers */ = {isa = PBXBuildFile; fileRef = C2FE18A316BAEC4000AF3061 /* StructureRareData.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49411BCD9DC9004C5B45 /* StructureRareDataInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = C20BA92C16BB1C1500B3AEA2 /* StructureRareDataInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49421BCD9DC9004C5B45 /* StructureSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F93329B14CA7DC10085F3C6 /* StructureSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49431BCD9DC9004C5B45 /* StructureStubClearingWatchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F766D3715AE4A1A008F363E /* StructureStubClearingWatchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49441BCD9DC9004C5B45 /* StructureStubInfo.h in Headers */ = {isa = PBXBuildFile; fileRef = BCCF0D070EF0AAB900413C8F /* StructureStubInfo.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49451BCD9DC9004C5B45 /* StructureTransitionTable.h in Headers */ = {isa = PBXBuildFile; fileRef = BC9041470EB9250900FE26FA /* StructureTransitionTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49461BCD9DC9004C5B45 /* SuperRegion.h in Headers */ = {isa = PBXBuildFile; fileRef = C2DF442E1707AC0100A5CA96 /* SuperRegion.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49471BCD9DC9004C5B45 /* SymbolTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 14A396A60CD2933100B5B4FF /* SymbolTable.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49481BCD9DC9004C5B45 /* SyntaxChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A7EE7711B98B8D0065A14F /* SyntaxChecker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49491BCD9DC9004C5B45 /* TestRunnerUtils.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FA2C17A17D7CF84009D015F /* TestRunnerUtils.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA494A1BCD9DC9004C5B45 /* ThunkGenerator.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F572D4D16879FDB00E57FBD /* ThunkGenerator.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA494B1BCD9DC9004C5B45 /* ThunkGenerators.h in Headers */ = {isa = PBXBuildFile; fileRef = A7386553118697B400540279 /* ThunkGenerators.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA494C1BCD9DC9004C5B45 /* TinyBloomFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = 141448CC13A1783700F5BA1A /* TinyBloomFilter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA494D1BCD9DC9004C5B45 /* ToNativeFromValue.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F55989717C86C5600A1E543 /* ToNativeFromValue.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA494E1BCD9DC9004C5B45 /* Tracing.h in Headers */ = {isa = PBXBuildFile; fileRef = 5D53726E0E1C54880021E549 /* Tracing.h */; };
+		A3CA494F1BCD9DC9004C5B45 /* TypedArrayAdaptors.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66D817B6B5AB00A7AE3F /* TypedArrayAdaptors.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49501BCD9DC9004C5B45 /* TypedArrayController.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66DA17B6B5AB00A7AE3F /* TypedArrayController.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49511BCD9DC9004C5B45 /* TypedArrayInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F4B94DB17B9F07500DD03A4 /* TypedArrayInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49521BCD9DC9004C5B45 /* TypedArrays.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66DB17B6B5AB00A7AE3F /* TypedArrays.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49531BCD9DC9004C5B45 /* TypedArrayType.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66DD17B6B5AB00A7AE3F /* TypedArrayType.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49541BCD9DC9004C5B45 /* udis86.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF4273F158EBD94004CB9FF /* udis86.h */; };
+		A3CA49551BCD9DC9004C5B45 /* udis86_decode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF42735158EBD94004CB9FF /* udis86_decode.h */; };
+		A3CA49561BCD9DC9004C5B45 /* udis86_extern.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF42736158EBD94004CB9FF /* udis86_extern.h */; };
+		A3CA49571BCD9DC9004C5B45 /* udis86_input.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF42738158EBD94004CB9FF /* udis86_input.h */; };
+		A3CA49581BCD9DC9004C5B45 /* udis86_syn.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF4273C158EBD94004CB9FF /* udis86_syn.h */; };
+		A3CA49591BCD9DC9004C5B45 /* udis86_types.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FF4273D158EBD94004CB9FF /* udis86_types.h */; };
+		A3CA495A1BCD9DC9004C5B45 /* UDis86Disassembler.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E5AB351799E4B200D2833D /* UDis86Disassembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA495B1BCD9DC9004C5B45 /* Uint16Array.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF3217ADB5F3005AB174 /* Uint16Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA495C1BCD9DC9004C5B45 /* Uint16WithFraction.h in Headers */ = {isa = PBXBuildFile; fileRef = 866739D113BFDE710023D87C /* Uint16WithFraction.h */; };
+		A3CA495D1BCD9DC9004C5B45 /* Uint32Array.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF3317ADB5F3005AB174 /* Uint32Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA495E1BCD9DC9004C5B45 /* Uint8Array.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF3017ADB5F3005AB174 /* Uint8Array.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA495F1BCD9DC9004C5B45 /* Uint8ClampedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = A7A8AF3117ADB5F3005AB174 /* Uint8ClampedArray.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49601BCD9DC9004C5B45 /* UnconditionalFinalizer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F5F08CE146C762F000472A9 /* UnconditionalFinalizer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49611BCD9DC9004C5B45 /* DFGAvailability.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F666EC31835672B00D017F1 /* DFGAvailability.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49621BCD9DC9004C5B45 /* UnlinkedCodeBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = A79E781F15EECBA80047C855 /* UnlinkedCodeBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49631BCD9DC9004C5B45 /* UnusedPointer.h in Headers */ = {isa = PBXBuildFile; fileRef = 65987F2F16828A7E003C2F8D /* UnusedPointer.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49641BCD9DC9004C5B45 /* ValueProfile.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F963B3613FC6FDE0002D9B2 /* ValueProfile.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49651BCD9DC9004C5B45 /* ValueRecovery.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F426A451460CBAB00131F8F /* ValueRecovery.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49661BCD9DC9004C5B45 /* VirtualRegister.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F426A461460CBAB00131F8F /* VirtualRegister.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49671BCD9DC9004C5B45 /* VM.h in Headers */ = {isa = PBXBuildFile; fileRef = E18E3A560DF9278C00D90B34 /* VM.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49681BCD9DC9004C5B45 /* VMInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = FE4A331E15BD2E07006F54F3 /* VMInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49691BCD9DC9004C5B45 /* InjectedScriptSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A513E5C6185F9436007E95AD /* InjectedScriptSource.h */; };
+		A3CA496A1BCD9DC9004C5B45 /* Watchdog.h in Headers */ = {isa = PBXBuildFile; fileRef = FED94F2C171E3E2300BE77A4 /* Watchdog.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA496B1BCD9DC9004C5B45 /* Watchpoint.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F919D2315853CDE004A4E7D /* Watchpoint.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA496C1BCD9DC9004C5B45 /* Weak.h in Headers */ = {isa = PBXBuildFile; fileRef = 142E3133134FF0A600AFADB5 /* Weak.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA496D1BCD9DC9004C5B45 /* WeakBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = 14E84F9A14EE1ACC00D6D5D4 /* WeakBlock.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA496E1BCD9DC9004C5B45 /* WeakGCMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 14BFCE6810CDB1FC00364CCE /* WeakGCMap.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA496F1BCD9DC9004C5B45 /* RemoteInspector.h in Headers */ = {isa = PBXBuildFile; fileRef = A5BA15E1182340B300A82E69 /* RemoteInspector.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49701BCD9DC9004C5B45 /* WeakHandleOwner.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F7256414EE265E00B1652B /* WeakHandleOwner.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49711BCD9DC9004C5B45 /* WeakImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = 14E84F9D14EE1ACC00D6D5D4 /* WeakImpl.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49721BCD9DC9004C5B45 /* WeakInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 14BE7D3217135CF400D1807A /* WeakInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49731BCD9DC9004C5B45 /* WeakMapConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A7CA3ADE17DA41AE006538AF /* WeakMapConstructor.h */; };
+		A3CA49741BCD9DC9004C5B45 /* WeakMapData.h in Headers */ = {isa = PBXBuildFile; fileRef = A7CA3AEA17DA5168006538AF /* WeakMapData.h */; };
+		A3CA49751BCD9DC9004C5B45 /* DFGStoreBarrierElisionPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 2ACCF3DD185FE26B0083E2AD /* DFGStoreBarrierElisionPhase.h */; };
+		A3CA49761BCD9DC9004C5B45 /* InspectorTypeBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A55D93AB18514F7900400DED /* InspectorTypeBuilder.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49771BCD9DC9004C5B45 /* WeakMapPrototype.h in Headers */ = {isa = PBXBuildFile; fileRef = A7CA3AE017DA41AE006538AF /* WeakMapPrototype.h */; };
+		A3CA49781BCD9DC9004C5B45 /* WeakRandom.h in Headers */ = {isa = PBXBuildFile; fileRef = 1420BE7A10AA6DDB00F455D2 /* WeakRandom.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49791BCD9DC9004C5B45 /* WeakReferenceHarvester.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F242DA513F3B1BB007ADD4C /* WeakReferenceHarvester.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA497A1BCD9DC9004C5B45 /* WeakSet.h in Headers */ = {isa = PBXBuildFile; fileRef = 14E84F9C14EE1ACC00D6D5D4 /* WeakSet.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA497B1BCD9DC9004C5B45 /* WeakSetInlines.h in Headers */ = {isa = PBXBuildFile; fileRef = 14150132154BB13F005D8C98 /* WeakSetInlines.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA497C1BCD9DC9004C5B45 /* WebKitAvailability.h in Headers */ = {isa = PBXBuildFile; fileRef = 5DE3D0F40DD8DDFB00468714 /* WebKitAvailability.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A3CA497D1BCD9DC9004C5B45 /* MapIteratorConstructor.h in Headers */ = {isa = PBXBuildFile; fileRef = A74DEF8C182D991400522C22 /* MapIteratorConstructor.h */; };
+		A3CA497E1BCD9DC9004C5B45 /* WriteBarrier.h in Headers */ = {isa = PBXBuildFile; fileRef = A7DCB77912E3D90500911940 /* WriteBarrier.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA497F1BCD9DC9004C5B45 /* WriteBarrierSupport.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC8150914043BD200CFA603 /* WriteBarrierSupport.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49801BCD9DC9004C5B45 /* X86Assembler.h in Headers */ = {isa = PBXBuildFile; fileRef = 9688CB140ED12B4E001D649F /* X86Assembler.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49811BCD9DC9004C5B45 /* Yarr.h in Headers */ = {isa = PBXBuildFile; fileRef = 451539B812DC994500EF7AC4 /* Yarr.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49821BCD9DC9004C5B45 /* DFGResurrectionForValidationPhase.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F666ECB1836B37E00D017F1 /* DFGResurrectionForValidationPhase.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49831BCD9DC9004C5B45 /* YarrInterpreter.h in Headers */ = {isa = PBXBuildFile; fileRef = 86704B7E12DBA33700A9FE7B /* YarrInterpreter.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49841BCD9DC9004C5B45 /* ScriptFunctionCall.h in Headers */ = {isa = PBXBuildFile; fileRef = A55D93A4185012A800400DED /* ScriptFunctionCall.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49851BCD9DC9004C5B45 /* YarrJIT.h in Headers */ = {isa = PBXBuildFile; fileRef = 86704B8012DBA33700A9FE7B /* YarrJIT.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49861BCD9DC9004C5B45 /* YarrParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 86704B8112DBA33700A9FE7B /* YarrParser.h */; settings = {ATTRIBUTES = (); }; };
+		A3CA49871BCD9DC9004C5B45 /* YarrPattern.h in Headers */ = {isa = PBXBuildFile; fileRef = 86704B8312DBA33700A9FE7B /* YarrPattern.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		A3CA49881BCD9DC9004C5B45 /* YarrSyntaxChecker.h in Headers */ = {isa = PBXBuildFile; fileRef = 86704B4112DB8A8100A9FE7B /* YarrSyntaxChecker.h */; };
+		A3CA498B1BCD9DC9004C5B45 /* ProtoCallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65FB5116184EE9BC00C12B70 /* ProtoCallFrame.cpp */; };
+		A3CA498C1BCD9DC9004C5B45 /* A64DOpcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 652A3A221651C69700A80AFE /* A64DOpcode.cpp */; };
+		A3CA498D1BCD9DC9004C5B45 /* AbstractPC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F55F0F114D1063600AC7649 /* AbstractPC.cpp */; };
+		A3CA498E1BCD9DC9004C5B45 /* ArgList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCF605110E203EF800B9A64D /* ArgList.cpp */; };
+		A3CA498F1BCD9DC9004C5B45 /* Arguments.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC257DE50E1F51C50016B6C9 /* Arguments.cpp */; };
+		A3CA49901BCD9DC9004C5B45 /* ArgumentsIteratorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A76140C7182982CB00750624 /* ArgumentsIteratorConstructor.cpp */; };
+		A3CA49911BCD9DC9004C5B45 /* ArgumentsIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A76140C9182982CB00750624 /* ArgumentsIteratorPrototype.cpp */; };
+		A3CA49921BCD9DC9004C5B45 /* ARM64Disassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 652A3A201651C66100A80AFE /* ARM64Disassembler.cpp */; };
+		A3CA49931BCD9DC9004C5B45 /* ARMAssembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86D3B2BF10156BDE002865E7 /* ARMAssembler.cpp */; };
+		A3CA49941BCD9DC9004C5B45 /* ARMv7Assembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A74DE1CB120B86D600D40D5B /* ARMv7Assembler.cpp */; };
+		A3CA49951BCD9DC9004C5B45 /* ARMv7Disassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65C0284F171795E200351E35 /* ARMv7Disassembler.cpp */; };
+		A3CA49961BCD9DC9004C5B45 /* ARMv7DOpcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65C0285A1717966800351E35 /* ARMv7DOpcode.cpp */; };
+		A3CA49971BCD9DC9004C5B45 /* ArrayAllocationProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8335B41639C1E3001443B5 /* ArrayAllocationProfile.cpp */; };
+		A3CA49981BCD9DC9004C5B45 /* ArrayBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7A8AF2517ADB5F2005AB174 /* ArrayBuffer.cpp */; };
+		A3CA49991BCD9DC9004C5B45 /* ArrayBufferView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7A8AF2717ADB5F3005AB174 /* ArrayBufferView.cpp */; };
+		A3CA499A1BCD9DC9004C5B45 /* ArrayConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC7952060E15E8A800A898AB /* ArrayConstructor.cpp */; };
+		A3CA499B1BCD9DC9004C5B45 /* ArrayIteratorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7BDAEC017F4EA1400F6140C /* ArrayIteratorConstructor.cpp */; };
+		A3CA499C1BCD9DC9004C5B45 /* ArrayIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7BDAEC217F4EA1400F6140C /* ArrayIteratorPrototype.cpp */; };
+		A3CA499D1BCD9DC9004C5B45 /* JSSetIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A790DD69182F499700588807 /* JSSetIterator.cpp */; };
+		A3CA499E1BCD9DC9004C5B45 /* ArrayProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F63945115D07051006A597C /* ArrayProfile.cpp */; };
+		A3CA499F1BCD9DC9004C5B45 /* ArrayPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A84D0255597D01FF60F7 /* ArrayPrototype.cpp */; };
+		A3CA49A01BCD9DC9004C5B45 /* AssemblyHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E53B17EA9F5900ABB217 /* AssemblyHelpers.cpp */; };
+		A3CA49A11BCD9DC9004C5B45 /* BlockAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14816E19154CC56C00B8054C /* BlockAllocator.cpp */; };
+		A3CA49A21BCD9DC9004C5B45 /* BooleanConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC7952320E15EB5600A898AB /* BooleanConstructor.cpp */; };
+		A3CA49A31BCD9DC9004C5B45 /* BooleanObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8500255597D01FF60F7 /* BooleanObject.cpp */; };
+		A3CA49A41BCD9DC9004C5B45 /* BooleanPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC7952340E15EB5600A898AB /* BooleanPrototype.cpp */; };
+		A3CA49A51BCD9DC9004C5B45 /* BytecodeGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 969A07200ED1CE3300F1F681 /* BytecodeGenerator.cpp */; };
+		A3CA49A61BCD9DC9004C5B45 /* CallData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCA62DFE0E2826230004F30D /* CallData.cpp */; };
+		A3CA49A71BCD9DC9004C5B45 /* CallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D8DB0ED2205B00B89619 /* CallFrame.cpp */; };
+		A3CA49A81BCD9DC9004C5B45 /* CallLinkInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0B83AE14BCF71400885B4F /* CallLinkInfo.cpp */; };
+		A3CA49A91BCD9DC9004C5B45 /* CallLinkStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F93329314CA7DC10085F3C6 /* CallLinkStatus.cpp */; };
+		A3CA49AA1BCD9DC9004C5B45 /* ClosureCallStubRoutine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F73D7AB165A142A00ACAB71 /* ClosureCallStubRoutine.cpp */; };
+		A3CA49AB1BCD9DC9004C5B45 /* CodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 969A07900ED1D3AE00F1F681 /* CodeBlock.cpp */; settings = {COMPILER_FLAGS = "-fno-strict-aliasing"; }; };
+		A3CA49AC1BCD9DC9004C5B45 /* CodeBlockHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F943D1667632D00D61971 /* CodeBlockHash.cpp */; };
+		A3CA49AD1BCD9DC9004C5B45 /* CodeBlockJettisoningWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC97F2F182020D7002C9B26 /* CodeBlockJettisoningWatchpoint.cpp */; };
+		A3CA49AE1BCD9DC9004C5B45 /* CodeBlockSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31117D4326C00CA2C40 /* CodeBlockSet.cpp */; };
+		A3CA49AF1BCD9DC9004C5B45 /* CodeCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77F181F164088B200640A47 /* CodeCache.cpp */; };
+		A3CA49B01BCD9DC9004C5B45 /* CodeOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F9445166764EE00D61971 /* CodeOrigin.cpp */; };
+		A3CA49B11BCD9DC9004C5B45 /* CodeProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86B5822E14D2373B00A9C306 /* CodeProfile.cpp */; };
+		A3CA49B21BCD9DC9004C5B45 /* CodeProfiling.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8603CEF214C7546400AE59E3 /* CodeProfiling.cpp */; };
+		A3CA49B31BCD9DC9004C5B45 /* CodeSpecializationKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F943A1667631100D61971 /* CodeSpecializationKind.cpp */; };
+		A3CA49B41BCD9DC9004C5B45 /* CodeType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F943F1667632D00D61971 /* CodeType.cpp */; };
+		A3CA49B51BCD9DC9004C5B45 /* CommonIdentifiers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65EA73620BAE35D1001BB560 /* CommonIdentifiers.cpp */; };
+		A3CA49B61BCD9DC9004C5B45 /* CommonSlowPaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A709F2F117A0AC2A00512E98 /* CommonSlowPaths.cpp */; };
+		A3CA49B71BCD9DC9004C5B45 /* CommonSlowPathsExceptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 6553A32F17A1F1EE008CF6F3 /* CommonSlowPathsExceptions.cpp */; };
+		A3CA49B81BCD9DC9004C5B45 /* CompilationResult.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E5A3A51797432D00E893C0 /* CompilationResult.cpp */; };
+		A3CA49B91BCD9DC9004C5B45 /* Completion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 969A09220ED1E09C00F1F681 /* Completion.cpp */; };
+		A3CA49BA1BCD9DC9004C5B45 /* ConservativeRoots.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 146B14DB12EB5B12001BEC1B /* ConservativeRoots.cpp */; };
+		A3CA49BB1BCD9DC9004C5B45 /* ConstructData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCA62DFF0E2826310004F30D /* ConstructData.cpp */; };
+		A3CA49BC1BCD9DC9004C5B45 /* CopiedSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C240305314B404C90079EB64 /* CopiedSpace.cpp */; };
+		A3CA49BD1BCD9DC9004C5B45 /* CopyVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2239D1216262BDD005AC5FD /* CopyVisitor.cpp */; };
+		A3CA49BE1BCD9DC9004C5B45 /* DataView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66B017B6B5AB00A7AE3F /* DataView.cpp */; };
+		A3CA49BF1BCD9DC9004C5B45 /* DateConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCD203450E17135E002C7E82 /* DateConstructor.cpp */; };
+		A3CA49C01BCD9DC9004C5B45 /* DateConversion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = D21202280AD4310C00ED79B6 /* DateConversion.cpp */; };
+		A3CA49C11BCD9DC9004C5B45 /* DateInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC1166000E1997B1008066DD /* DateInstance.cpp */; };
+		A3CA49C21BCD9DC9004C5B45 /* DatePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCD203470E17135E002C7E82 /* DatePrototype.cpp */; };
+		A3CA49C31BCD9DC9004C5B45 /* BytecodeLivenessAnalysis.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2FCAE0E17A9C24E0034C735 /* BytecodeLivenessAnalysis.cpp */; };
+		A3CA49C41BCD9DC9004C5B45 /* Debugger.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8580255597D01FF60F7 /* Debugger.cpp */; };
+		A3CA49C51BCD9DC9004C5B45 /* DebuggerActivation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC3135630F302FA3003DFD3A /* DebuggerActivation.cpp */; };
+		A3CA49C61BCD9DC9004C5B45 /* DebuggerCallFrame.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 149559ED0DDCDDF700648087 /* DebuggerCallFrame.cpp */; };
+		A3CA49C71BCD9DC9004C5B45 /* DeferGC.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A7A58EE1808A4C40020BDF7 /* DeferGC.cpp */; };
+		A3CA49C81BCD9DC9004C5B45 /* DeferredCompilationCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC712DC17CD8778008CC93C /* DeferredCompilationCallback.cpp */; };
+		A3CA49C91BCD9DC9004C5B45 /* DFGAbstractHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77A423617A0BBFD00A8DB81 /* DFGAbstractHeap.cpp */; };
+		A3CA49CA1BCD9DC9004C5B45 /* DFGAbstractValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F55C19317276E4600CEABFD /* DFGAbstractValue.cpp */; };
+		A3CA49CB1BCD9DC9004C5B45 /* DFGArgumentsSimplificationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F16015A156198BF00C2587C /* DFGArgumentsSimplificationPhase.cpp */; };
+		A3CA49CC1BCD9DC9004C5B45 /* DFGArrayMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F63948115E48114006A597C /* DFGArrayMode.cpp */; };
+		A3CA49CD1BCD9DC9004C5B45 /* DFGAtTailAbstractState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D9A28F17A0BC7400EE2618 /* DFGAtTailAbstractState.cpp */; };
+		A3CA49CE1BCD9DC9004C5B45 /* DFGBackwardsPropagationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F714CA116EA92ED00F3EBEB /* DFGBackwardsPropagationPhase.cpp */; };
+		A3CA49CF1BCD9DC9004C5B45 /* DFGBasicBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CE317A0B8CC00773AD8 /* DFGBasicBlock.cpp */; };
+		A3CA49D01BCD9DC9004C5B45 /* DFGBinarySwitch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A70B083017A0B79B00DAF14B /* DFGBinarySwitch.cpp */; };
+		A3CA49D11BCD9DC9004C5B45 /* DFGBlockInsertionSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CE417A0B8CC00773AD8 /* DFGBlockInsertionSet.cpp */; };
+		A3CA49D21BCD9DC9004C5B45 /* DFGByteCodeParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DB41328DF82002B2AD7 /* DFGByteCodeParser.cpp */; };
+		A3CA49D31BCD9DC9004C5B45 /* DFGCapabilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD82E1E14172C2F00179C94 /* DFGCapabilities.cpp */; };
+		A3CA49D41BCD9DC9004C5B45 /* DFGCFAPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC94B14EF909500C72532 /* DFGCFAPhase.cpp */; };
+		A3CA49D51BCD9DC9004C5B45 /* DFGCFGSimplificationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3B3A241544C991003ED0FF /* DFGCFGSimplificationPhase.cpp */; };
+		A3CA49D61BCD9DC9004C5B45 /* DFGClobberize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77A423817A0BBFD00A8DB81 /* DFGClobberize.cpp */; };
+		A3CA49D71BCD9DC9004C5B45 /* DFGClobberSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A77A423A17A0BBFD00A8DB81 /* DFGClobberSet.cpp */; };
+		A3CA49D81BCD9DC9004C5B45 /* DFGCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B51A16B62772003F696B /* DFGCommon.cpp */; };
+		A3CA49D91BCD9DC9004C5B45 /* DFGCommonData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A2D170D40BF00BB722C /* DFGCommonData.cpp */; };
+		A3CA49DA1BCD9DC9004C5B45 /* DFGCompilationKey.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F38B01317CFE75500B144D3 /* DFGCompilationKey.cpp */; };
+		A3CA49DB1BCD9DC9004C5B45 /* DFGCompilationMode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F38B01517CFE75500B144D3 /* DFGCompilationMode.cpp */; };
+		A3CA49DC1BCD9DC9004C5B45 /* DFGConstantFoldingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3B3A17153E68EF003ED0FF /* DFGConstantFoldingPhase.cpp */; };
+		A3CA49DD1BCD9DC9004C5B45 /* DFGCPSRethreadingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBE0F6B16C1DB010082C5E8 /* DFGCPSRethreadingPhase.cpp */; };
+		A3CA49DE1BCD9DC9004C5B45 /* DFGCriticalEdgeBreakingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CE617A0B8CC00773AD8 /* DFGCriticalEdgeBreakingPhase.cpp */; };
+		A3CA49DF1BCD9DC9004C5B45 /* DFGCSEPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC94D14EF909500C72532 /* DFGCSEPhase.cpp */; };
+		A3CA49E01BCD9DC9004C5B45 /* DFGDCEPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2FC77016E12F6F0038D976 /* DFGDCEPhase.cpp */; };
+		A3CA49E11BCD9DC9004C5B45 /* DFGDesiredIdentifiers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F2B97172F04FD007DBDA5 /* DFGDesiredIdentifiers.cpp */; };
+		A3CA49E21BCD9DC9004C5B45 /* DFGDesiredStructureChains.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A73E132C179624CD00E4DEA8 /* DFGDesiredStructureChains.cpp */; };
+		A3CA49E31BCD9DC9004C5B45 /* DFGDesiredTransitions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2C0F7CB17BBFC5B00464FE4 /* DFGDesiredTransitions.cpp */; };
+		A3CA49E41BCD9DC9004C5B45 /* DFGDesiredWatchpoints.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE853491723CDA500B618F5 /* DFGDesiredWatchpoints.cpp */; };
+		A3CA49E51BCD9DC9004C5B45 /* DFGDesiredWeakReferences.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2981FD617BAEE4B00A3BC98 /* DFGDesiredWeakReferences.cpp */; };
+		A3CA49E61BCD9DC9004C5B45 /* DFGDesiredWriteBarriers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2981FDA17BAFF4400A3BC98 /* DFGDesiredWriteBarriers.cpp */; };
+		A3CA49E71BCD9DC9004C5B45 /* DFGDisassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF427611591A1C9004CB9FF /* DFGDisassembler.cpp */; };
+		A3CA49E81BCD9DC9004C5B45 /* DFGDominators.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD81ACF154FB4EB00983E72 /* DFGDominators.cpp */; };
+		A3CA49E91BCD9DC9004C5B45 /* DFGDriver.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD3C82014115CF800FD81CB /* DFGDriver.cpp */; };
+		A3CA49EA1BCD9DC9004C5B45 /* InspectorValues.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A593CF801840377100BFCE27 /* InspectorValues.cpp */; };
+		A3CA49EB1BCD9DC9004C5B45 /* DFGEdge.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B51B16B62772003F696B /* DFGEdge.cpp */; };
+		A3CA49EC1BCD9DC9004C5B45 /* MapIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A74DEF8D182D991400522C22 /* MapIteratorPrototype.cpp */; };
+		A3CA49ED1BCD9DC9004C5B45 /* DFGExitProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBC0AE41496C7C100D4FBDD /* DFGExitProfile.cpp */; };
+		A3CA49EE1BCD9DC9004C5B45 /* DFGFailedFinalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A976C179738B8009DF744 /* DFGFailedFinalizer.cpp */; };
+		A3CA49EF1BCD9DC9004C5B45 /* DFGFinalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A976E179738B8009DF744 /* DFGFinalizer.cpp */; };
+		A3CA49F01BCD9DC9004C5B45 /* DFGFixupPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC12151C5D4A00CD8910 /* DFGFixupPhase.cpp */; };
+		A3CA49F11BCD9DC9004C5B45 /* DFGFlushedAt.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D339417FFC4E60073C2BC /* DFGFlushedAt.cpp */; };
+		A3CA49F21BCD9DC9004C5B45 /* DFGFlushFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CE817A0B8CC00773AD8 /* DFGFlushFormat.cpp */; };
+		A3CA49F31BCD9DC9004C5B45 /* DFGFlushLivenessAnalysisPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CEA17A0B8CC00773AD8 /* DFGFlushLivenessAnalysisPhase.cpp */; };
+		A3CA49F41BCD9DC9004C5B45 /* DFGGraph.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DB71328DF82002B2AD7 /* DFGGraph.cpp */; };
+		A3CA49F51BCD9DC9004C5B45 /* DFGInPlaceAbstractState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A704D90017A0BAA8006BA554 /* DFGInPlaceAbstractState.cpp */; };
+		A3CA49F61BCD9DC9004C5B45 /* DFGInvalidationPointInjectionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC97F3718202119002C9B26 /* DFGInvalidationPointInjectionPhase.cpp */; };
+		A3CA49F71BCD9DC9004C5B45 /* DFGJITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A2F170D40BF00BB722C /* DFGJITCode.cpp */; };
+		A3CA49F81BCD9DC9004C5B45 /* DFGJITCompiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DBB1328DF82002B2AD7 /* DFGJITCompiler.cpp */; };
+		A3CA49F91BCD9DC9004C5B45 /* DFGJITFinalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A9770179738B8009DF744 /* DFGJITFinalizer.cpp */; };
+		A3CA49FA1BCD9DC9004C5B45 /* DFGJumpReplacement.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC97F3918202119002C9B26 /* DFGJumpReplacement.cpp */; };
+		A3CA49FB1BCD9DC9004C5B45 /* DFGLazyJSValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A73A53581799CD5D00170C19 /* DFGLazyJSValue.cpp */; };
+		A3CA49FC1BCD9DC9004C5B45 /* DFGLICMPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D9A29217A0BC7400EE2618 /* DFGLICMPhase.cpp */; };
+		A3CA49FD1BCD9DC9004C5B45 /* DFGLivenessAnalysisPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CEC17A0B8CC00773AD8 /* DFGLivenessAnalysisPhase.cpp */; };
+		A3CA49FE1BCD9DC9004C5B45 /* DFGLongLivedState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B51C16B62772003F696B /* DFGLongLivedState.cpp */; };
+		A3CA49FF1BCD9DC9004C5B45 /* DFGLoopPreHeaderCreationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A767B5B317A0B9650063D940 /* DFGLoopPreHeaderCreationPhase.cpp */; };
+		A3CA4A001BCD9DC9004C5B45 /* DFGMinifiedNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC4C1522818300CD8910 /* DFGMinifiedNode.cpp */; };
+		A3CA4A011BCD9DC9004C5B45 /* DFGNaturalLoops.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A737810A1799EA2E00817533 /* DFGNaturalLoops.cpp */; };
+		A3CA4A021BCD9DC9004C5B45 /* DFGNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B51E16B62772003F696B /* DFGNode.cpp */; };
+		A3CA4A031BCD9DC9004C5B45 /* DFGNodeFlags.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA581B7150E952A00B9A2D9 /* DFGNodeFlags.cpp */; };
+		A3CA4A041BCD9DC9004C5B45 /* DFGOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DBF1328DF82002B2AD7 /* DFGOperations.cpp */; };
+		A3CA4A051BCD9DC9004C5B45 /* DFGOSRAvailabilityAnalysisPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CEE17A0B8CC00773AD8 /* DFGOSRAvailabilityAnalysisPhase.cpp */; };
+		A3CA4A061BCD9DC9004C5B45 /* DFGOSREntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD82E52141DAEDE00179C94 /* DFGOSREntry.cpp */; };
+		A3CA4A071BCD9DC9004C5B45 /* DFGOSREntrypointCreationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31D17D51F5700CA2C40 /* DFGOSREntrypointCreationPhase.cpp */; };
+		A3CA4A081BCD9DC9004C5B45 /* DFGOSRExit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC0978E146A6F6300CF2442 /* DFGOSRExit.cpp */; };
+		A3CA4A091BCD9DC9004C5B45 /* DFGOSRExitBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BE717178E7300690C7F /* DFGOSRExitBase.cpp */; };
+		A3CA4A0A1BCD9DC9004C5B45 /* DFGOSRExitCompiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC0978F146A6F6300CF2442 /* DFGOSRExitCompiler.cpp */; };
+		A3CA4A0B1BCD9DC9004C5B45 /* DFGOSRExitCompiler32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC09775146943AD00CF2442 /* DFGOSRExitCompiler32_64.cpp */; };
+		A3CA4A0C1BCD9DC9004C5B45 /* DFGStrengthReductionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC20CB31852E2C600C9E954 /* DFGStrengthReductionPhase.cpp */; };
+		A3CA4A0D1BCD9DC9004C5B45 /* DFGOSRExitCompiler64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC0977014693AEF00CF2442 /* DFGOSRExitCompiler64.cpp */; };
+		A3CA4A0E1BCD9DC9004C5B45 /* DFGOSRExitCompilerCommon.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7025A71714B0F800382C0E /* DFGOSRExitCompilerCommon.cpp */; };
+		A3CA4A0F1BCD9DC9004C5B45 /* DFGOSRExitJumpPlaceholder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEFC9A71681A3B000567F53 /* DFGOSRExitJumpPlaceholder.cpp */; };
+		A3CA4A101BCD9DC9004C5B45 /* DFGOSRExitPreparation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BE917178E7300690C7F /* DFGOSRExitPreparation.cpp */; };
+		A3CA4A111BCD9DC9004C5B45 /* DFGPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC94F14EF909500C72532 /* DFGPhase.cpp */; };
+		A3CA4A121BCD9DC9004C5B45 /* DFGPlan.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A9772179738B8009DF744 /* DFGPlan.cpp */; };
+		A3CA4A131BCD9DC9004C5B45 /* DFGPredictionInjectionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBE0F6D16C1DB010082C5E8 /* DFGPredictionInjectionPhase.cpp */; };
+		A3CA4A141BCD9DC9004C5B45 /* DFGPredictionPropagationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC95114EF909500C72532 /* DFGPredictionPropagationPhase.cpp */; };
+		A3CA4A151BCD9DC9004C5B45 /* DFGSpeculativeJIT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EC9DC21328DF82002B2AD7 /* DFGSpeculativeJIT.cpp */; };
+		A3CA4A161BCD9DC9004C5B45 /* DFGSpeculativeJIT32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86880F1B14328BB900B08D42 /* DFGSpeculativeJIT32_64.cpp */; };
+		A3CA4A171BCD9DC9004C5B45 /* DFGSpeculativeJIT64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86880F4C14353B2100B08D42 /* DFGSpeculativeJIT64.cpp */; };
+		A3CA4A181BCD9DC9004C5B45 /* DFGSSAConversionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7D89CF017A0B8CC00773AD8 /* DFGSSAConversionPhase.cpp */; };
+		A3CA4A191BCD9DC9004C5B45 /* DFGStackLayoutPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9FB4F217FCB91700CB67F8 /* DFGStackLayoutPhase.cpp */; };
+		A3CA4A1A1BCD9DC9004C5B45 /* DFGThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC0979F146B28C700CF2442 /* DFGThunks.cpp */; };
+		A3CA4A1B1BCD9DC9004C5B45 /* DFGTierUpCheckInjectionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31F17D51F5700CA2C40 /* DFGTierUpCheckInjectionPhase.cpp */; };
+		A3CA4A1C1BCD9DC9004C5B45 /* DFGToFTLDeferredCompilationCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A32117D51F5700CA2C40 /* DFGToFTLDeferredCompilationCallback.cpp */; };
+		A3CA4A1D1BCD9DC9004C5B45 /* DFGToFTLForOSREntryDeferredCompilationCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A32317D51F5700CA2C40 /* DFGToFTLForOSREntryDeferredCompilationCallback.cpp */; };
+		A3CA4A1E1BCD9DC9004C5B45 /* DFGTypeCheckHoistingPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F63943C15C75F14006A597C /* DFGTypeCheckHoistingPhase.cpp */; };
+		A3CA4A1F1BCD9DC9004C5B45 /* DFGUnificationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FBE0F6F16C1DB010082C5E8 /* DFGUnificationPhase.cpp */; };
+		A3CA4A201BCD9DC9004C5B45 /* DFGUseKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F34B14716D4200E001CDA5A /* DFGUseKind.cpp */; };
+		A3CA4A211BCD9DC9004C5B45 /* DFGValidate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F3B3A2915474FF4003ED0FF /* DFGValidate.cpp */; };
+		A3CA4A221BCD9DC9004C5B45 /* ScriptFunctionCall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A55D93A3185012A800400DED /* ScriptFunctionCall.cpp */; };
+		A3CA4A231BCD9DC9004C5B45 /* DFGValueSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC4E15228BE700CD8910 /* DFGValueSource.cpp */; };
+		A3CA4A241BCD9DC9004C5B45 /* DFGVariableAccessDataDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDDBFB21666EED500C55FEF /* DFGVariableAccessDataDump.cpp */; };
+		A3CA4A251BCD9DC9004C5B45 /* DFGVariableEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC5015228FFA00CD8910 /* DFGVariableEvent.cpp */; };
+		A3CA4A261BCD9DC9004C5B45 /* DFGVariableEventStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2BDC421522801700CD8910 /* DFGVariableEventStream.cpp */; };
+		A3CA4A271BCD9DC9004C5B45 /* DFGVirtualRegisterAllocationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFFC95314EF909500C72532 /* DFGVirtualRegisterAllocationPhase.cpp */; };
+		A3CA4A281BCD9DC9004C5B45 /* DFGWatchpointCollectionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC97F3B18202119002C9B26 /* DFGWatchpointCollectionPhase.cpp */; };
+		A3CA4A291BCD9DC9004C5B45 /* DFGWorklist.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDB2CE5174830A2007B3C1B /* DFGWorklist.cpp */; };
+		A3CA4A2A1BCD9DC9004C5B45 /* Disassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D336E165DBB8D005AD387 /* Disassembler.cpp */; };
+		A3CA4A2B1BCD9DC9004C5B45 /* DumpContext.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A70447EB17A0BD7000F5898E /* DumpContext.cpp */; };
+		A3CA4A2C1BCD9DC9004C5B45 /* Error.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC337BEA0E1B00CB0076918A /* Error.cpp */; };
+		A3CA4A2D1BCD9DC9004C5B45 /* ErrorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9040E1839DB000F9297 /* ErrorConstructor.cpp */; };
+		A3CA4A2E1BCD9DC9004C5B45 /* ErrorInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E98A0E183E38000F9297 /* ErrorInstance.cpp */; };
+		A3CA4A2F1BCD9DC9004C5B45 /* ErrorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9060E1839DB000F9297 /* ErrorPrototype.cpp */; };
+		A3CA4A301BCD9DC9004C5B45 /* JSTypedArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 104A28CA188A011B002CCBE0 /* JSTypedArray.cpp */; };
+		A3CA4A311BCD9DC9004C5B45 /* ExceptionHelpers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D8770ED21ACD00B89619 /* ExceptionHelpers.cpp */; };
+		A3CA4A321BCD9DC9004C5B45 /* Executable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86CA032D1038E8440028A609 /* Executable.cpp */; };
+		A3CA4A331BCD9DC9004C5B45 /* ExecutableAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7B48DB60EE74CFC00DCBDB6 /* ExecutableAllocator.cpp */; };
+		A3CA4A341BCD9DC9004C5B45 /* ExecutableAllocatorFixedVMPool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86DB64630F95C6FC00D7D921 /* ExecutableAllocatorFixedVMPool.cpp */; };
+		A3CA4A351BCD9DC9004C5B45 /* ExecutionCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F56A1D415001CF2002992B1 /* ExecutionCounter.cpp */; };
+		A3CA4A361BCD9DC9004C5B45 /* JSGlobalObjectDebuggable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A59455901824744700CC3843 /* JSGlobalObjectDebuggable.cpp */; };
+		A3CA4A371BCD9DC9004C5B45 /* ExitKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB105821675480C00F8AB6E /* ExitKind.cpp */; };
+		A3CA4A381BCD9DC9004C5B45 /* ScriptValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A54CF2F2184EAB2400237F19 /* ScriptValue.cpp */; };
+		A3CA4A391BCD9DC9004C5B45 /* FTLAbstractHeap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A171708B00700BB722C /* FTLAbstractHeap.cpp */; };
+		A3CA4A3A1BCD9DC9004C5B45 /* FTLAbstractHeapRepository.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A191708B00700BB722C /* FTLAbstractHeapRepository.cpp */; };
+		A3CA4A3B1BCD9DC9004C5B45 /* FTLCapabilities.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA09FE170513DB00BB722C /* FTLCapabilities.cpp */; };
+		A3CA4A3C1BCD9DC9004C5B45 /* FTLCommonValues.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A251709623B00BB722C /* FTLCommonValues.cpp */; };
+		A3CA4A3D1BCD9DC9004C5B45 /* JSPromiseDeferred.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C008CD8187124BB00955C24 /* JSPromiseDeferred.cpp */; };
+		A3CA4A3E1BCD9DC9004C5B45 /* InspectorJSFrontendDispatchers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A532438318568317002ED692 /* InspectorJSFrontendDispatchers.cpp */; };
+		A3CA4A3F1BCD9DC9004C5B45 /* FTLCompile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A00170513DB00BB722C /* FTLCompile.cpp */; };
+		A3CA4A401BCD9DC9004C5B45 /* FTLExitArgument.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BBD17178E1C00690C7F /* FTLExitArgument.cpp */; };
+		A3CA4A411BCD9DC9004C5B45 /* FTLExitArgumentForOperand.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BBF17178E1C00690C7F /* FTLExitArgumentForOperand.cpp */; };
+		A3CA4A421BCD9DC9004C5B45 /* FTLExitThunkGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BC217178E1C00690C7F /* FTLExitThunkGenerator.cpp */; };
+		A3CA4A431BCD9DC9004C5B45 /* FTLExitValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BC417178E1C00690C7F /* FTLExitValue.cpp */; };
+		A3CA4A441BCD9DC9004C5B45 /* FTLFail.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7F2996917A0BB670010417A /* FTLFail.cpp */; };
+		A3CA4A451BCD9DC9004C5B45 /* FTLForOSREntryJITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31517D51F2200CA2C40 /* FTLForOSREntryJITCode.cpp */; };
+		A3CA4A461BCD9DC9004C5B45 /* FTLInlineCacheSize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F25F1A8181635F300522F39 /* FTLInlineCacheSize.cpp */; };
+		A3CA4A471BCD9DC9004C5B45 /* FTLIntrinsicRepository.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A261709623B00BB722C /* FTLIntrinsicRepository.cpp */; };
+		A3CA4A481BCD9DC9004C5B45 /* FTLJITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A02170513DB00BB722C /* FTLJITCode.cpp */; };
+		A3CA4A491BCD9DC9004C5B45 /* FTLJITFinalizer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78A977D179738D5009DF744 /* FTLJITFinalizer.cpp */; };
+		A3CA4A4A1BCD9DC9004C5B45 /* FTLLink.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F2B93172E049E007DBDA5 /* FTLLink.cpp */; };
+		A3CA4A4B1BCD9DC9004C5B45 /* JSMapIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A74DEF8F182D991400522C22 /* JSMapIterator.cpp */; };
+		A3CA4A4C1BCD9DC9004C5B45 /* FTLLocation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FCEFADD180738C000472CE4 /* FTLLocation.cpp */; };
+		A3CA4A4D1BCD9DC9004C5B45 /* FTLLowerDFGToLLVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A04170513DB00BB722C /* FTLLowerDFGToLLVM.cpp */; };
+		A3CA4A4E1BCD9DC9004C5B45 /* FTLOSREntry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD8A31717D51F2200CA2C40 /* FTLOSREntry.cpp */; };
+		A3CA4A4F1BCD9DC9004C5B45 /* FTLOSRExit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BC617178E1C00690C7F /* FTLOSRExit.cpp */; };
+		A3CA4A501BCD9DC9004C5B45 /* FTLOSRExitCompiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BC917178E1C00690C7F /* FTLOSRExitCompiler.cpp */; };
+		A3CA4A511BCD9DC9004C5B45 /* FTLOutput.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A291709629600BB722C /* FTLOutput.cpp */; };
+		A3CA4A521BCD9DC9004C5B45 /* FTLSaveRestore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FCEFAA91804C13E00472CE4 /* FTLSaveRestore.cpp */; };
+		A3CA4A531BCD9DC9004C5B45 /* FTLSlowPathCall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F25F1AA181635F300522F39 /* FTLSlowPathCall.cpp */; };
+		A3CA4A541BCD9DC9004C5B45 /* FTLSlowPathCallKey.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F25F1AC181635F300522F39 /* FTLSlowPathCallKey.cpp */; };
+		A3CA4A551BCD9DC9004C5B45 /* FTLStackMaps.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D33981803ADB70073C2BC /* FTLStackMaps.cpp */; };
+		A3CA4A561BCD9DC9004C5B45 /* FTLState.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEA0A151706BB9000BB722C /* FTLState.cpp */; };
+		A3CA4A571BCD9DC9004C5B45 /* JSPromiseFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C008CD0186F8A9300955C24 /* JSPromiseFunctions.cpp */; };
+		A3CA4A581BCD9DC9004C5B45 /* FTLThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BCB17178E1C00690C7F /* FTLThunks.cpp */; };
+		A3CA4A591BCD9DC9004C5B45 /* InspectorBackendDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A593CF7A1840360300BFCE27 /* InspectorBackendDispatcher.cpp */; };
+		A3CA4A5A1BCD9DC9004C5B45 /* FTLValueFormat.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F235BCD17178E1C00690C7F /* FTLValueFormat.cpp */; };
+		A3CA4A5B1BCD9DC9004C5B45 /* FunctionConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C00E16D4E900A06E92 /* FunctionConstructor.cpp */; };
+		A3CA4A5C1BCD9DC9004C5B45 /* FunctionExecutableDump.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB4B52116B6278D003F696B /* FunctionExecutableDump.cpp */; };
+		A3CA4A5D1BCD9DC9004C5B45 /* FunctionPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A85C0255597D01FF60F7 /* FunctionPrototype.cpp */; };
+		A3CA4A5E1BCD9DC9004C5B45 /* GCActivityCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2D58C3315912FEE0021A844 /* GCActivityCallback.cpp */; };
+		A3CA4A5F1BCD9DC9004C5B45 /* GCAwareJITStubRoutine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F766D2D15A8DCDD008F363E /* GCAwareJITStubRoutine.cpp */; };
+		A3CA4A601BCD9DC9004C5B45 /* GCThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2239D1516262BDD005AC5FD /* GCThread.cpp */; };
+		A3CA4A611BCD9DC9004C5B45 /* GCThreadSharedData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C21122DE15DD9AB300790E3A /* GCThreadSharedData.cpp */; };
+		A3CA4A621BCD9DC9004C5B45 /* GetByIdStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F93329514CA7DC10085F3C6 /* GetByIdStatus.cpp */; };
+		A3CA4A631BCD9DC9004C5B45 /* JSPromiseReaction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C008CDC1871258D00955C24 /* JSPromiseReaction.cpp */; };
+		A3CA4A641BCD9DC9004C5B45 /* GetterSetter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9B80E184545000F9297 /* GetterSetter.cpp */; };
+		A3CA4A651BCD9DC9004C5B45 /* HandleSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 142E312C134FF0A600AFADB5 /* HandleSet.cpp */; };
+		A3CA4A661BCD9DC9004C5B45 /* HandleStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 142E312E134FF0A600AFADB5 /* HandleStack.cpp */; };
+		A3CA4A671BCD9DC9004C5B45 /* Heap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14BA7A9513AADFF8005B7C2C /* Heap.cpp */; };
+		A3CA4A681BCD9DC9004C5B45 /* HeapStatistics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C24D31E0161CD695002AA4DB /* HeapStatistics.cpp */; };
+		A3CA4A691BCD9DC9004C5B45 /* HeapTimer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2E526BB1590EF000054E48D /* HeapTimer.cpp */; };
+		A3CA4A6A1BCD9DC9004C5B45 /* HostCallReturnValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4680D014BBC5F800BFE272 /* HostCallReturnValue.cpp */; };
+		A3CA4A6B1BCD9DC9004C5B45 /* Identifier.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 933A349D038AE80F008635CE /* Identifier.cpp */; };
+		A3CA4A6C1BCD9DC9004C5B45 /* IncrementalSweeper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C25F8BCB157544A900245B71 /* IncrementalSweeper.cpp */; };
+		A3CA4A6D1BCD9DC9004C5B45 /* IndexingType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F13E04C16164A1B00DC8DE7 /* IndexingType.cpp */; };
+		A3CA4A6E1BCD9DC9004C5B45 /* InitializeLLVM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FCEFAC41805E75500472CE4 /* InitializeLLVM.cpp */; };
+		A3CA4A6F1BCD9DC9004C5B45 /* InitializeLLVMMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 0FCEFAAF1805CA6D00472CE4 /* InitializeLLVMMac.mm */; };
+		A3CA4A701BCD9DC9004C5B45 /* InitializeLLVMPOSIX.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FCEFAC51805E75500472CE4 /* InitializeLLVMPOSIX.cpp */; };
+		A3CA4A711BCD9DC9004C5B45 /* InitializeThreading.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E178636C0D9BEEC300D74E75 /* InitializeThreading.cpp */; };
+		A3CA4A721BCD9DC9004C5B45 /* InlineCallFrameSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E55317F0B71C00ABB217 /* InlineCallFrameSet.cpp */; };
+		A3CA4A731BCD9DC9004C5B45 /* IntendedStructureChain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78853F717972629001440E4 /* IntendedStructureChain.cpp */; };
+		A3CA4A741BCD9DC9004C5B45 /* InternalFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC9BB95B0E19680600DF8855 /* InternalFunction.cpp */; };
+		A3CA4A751BCD9DC9004C5B45 /* DFGStoreBarrierElisionPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2ACCF3DC185FE26B0083E2AD /* DFGStoreBarrierElisionPhase.cpp */; };
+		A3CA4A761BCD9DC9004C5B45 /* Interpreter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D7D30ED2128200B89619 /* Interpreter.cpp */; };
+		A3CA4A771BCD9DC9004C5B45 /* JIT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D92D0ED22D7000B89619 /* JIT.cpp */; };
+		A3CA4A781BCD9DC9004C5B45 /* JITArithmetic.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86A90ECF0EE7D51F00AB350D /* JITArithmetic.cpp */; };
+		A3CA4A791BCD9DC9004C5B45 /* JITArithmetic32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A75706DD118A2BCF0057F88F /* JITArithmetic32_64.cpp */; };
+		A3CA4A7A1BCD9DC9004C5B45 /* JITCall.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86CC85A20EE79B7400288682 /* JITCall.cpp */; };
+		A3CA4A7B1BCD9DC9004C5B45 /* JITCall32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 146FE51111A710430087AE66 /* JITCall32_64.cpp */; };
+		A3CA4A7C1BCD9DC9004C5B45 /* JITCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F94431667635200D61971 /* JITCode.cpp */; };
+		A3CA4A7D1BCD9DC9004C5B45 /* JITDisassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FAF7EFA165BA919000C8455 /* JITDisassembler.cpp */; };
+		A3CA4A7E1BCD9DC9004C5B45 /* JITExceptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F46807F14BA572700BFE272 /* JITExceptions.cpp */; };
+		A3CA4A7F1BCD9DC9004C5B45 /* JITInlineCacheGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB14E1C18124ACE009B6B4D /* JITInlineCacheGenerator.cpp */; };
+		A3CA4A801BCD9DC9004C5B45 /* JITOpcodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCDD51E90FB8DF74004A8BDC /* JITOpcodes.cpp */; };
+		A3CA4A811BCD9DC9004C5B45 /* JITOpcodes32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A71236E41195F33C00BD2174 /* JITOpcodes32_64.cpp */; };
+		A3CA4A821BCD9DC9004C5B45 /* WriteBarrierBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2A4EC9091860D6C20094F782 /* WriteBarrierBuffer.cpp */; };
+		A3CA4A831BCD9DC9004C5B45 /* JITOperations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E54517EE274900ABB217 /* JITOperations.cpp */; };
+		A3CA4A841BCD9DC9004C5B45 /* JITPropertyAccess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86CC85C30EE7A89400288682 /* JITPropertyAccess.cpp */; };
+		A3CA4A851BCD9DC9004C5B45 /* JITPropertyAccess32_64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7C1E8C8112E701C00A37F98 /* JITPropertyAccess32_64.cpp */; };
+		A3CA4A861BCD9DC9004C5B45 /* JITStubRoutine.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F766D2615A8CC1B008F363E /* JITStubRoutine.cpp */; };
+		A3CA4A871BCD9DC9004C5B45 /* JITStubRoutineSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F766D2915A8CC34008F363E /* JITStubRoutineSet.cpp */; };
+		A3CA4A881BCD9DC9004C5B45 /* JITStubs.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14A23D6C0F4E19CE0023CDAD /* JITStubs.cpp */; };
+		A3CA4A891BCD9DC9004C5B45 /* JITThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5EF91B16878F78003E5C25 /* JITThunks.cpp */; };
+		A3CA4A8A1BCD9DC9004C5B45 /* JITToDFGDeferredCompilationCallback.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC712E017CD878F008CC93C /* JITToDFGDeferredCompilationCallback.cpp */; };
+		A3CA4A8B1BCD9DC9004C5B45 /* JSActivation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14DA818F0D99FD2000B0A4FB /* JSActivation.cpp */; };
+		A3CA4A8C1BCD9DC9004C5B45 /* JSAPIValueWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC0894D50FAFBA2D00001865 /* JSAPIValueWrapper.cpp */; };
+		A3CA4A8D1BCD9DC9004C5B45 /* JSAPIWrapperObject.mm in Sources */ = {isa = PBXBuildFile; fileRef = C2CF39BF16E15A8100DD69BE /* JSAPIWrapperObject.mm */; };
+		A3CA4A8E1BCD9DC9004C5B45 /* JSArgumentsIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A76140CB182982CB00750624 /* JSArgumentsIterator.cpp */; };
+		A3CA4A8F1BCD9DC9004C5B45 /* JSArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93ADFCE60CCBD7AC00D30B08 /* JSArray.cpp */; };
+		A3CA4A901BCD9DC9004C5B45 /* JSArrayBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66B417B6B5AB00A7AE3F /* JSArrayBuffer.cpp */; };
+		A3CA4A911BCD9DC9004C5B45 /* JSArrayBufferConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66B617B6B5AB00A7AE3F /* JSArrayBufferConstructor.cpp */; };
+		A3CA4A921BCD9DC9004C5B45 /* JSArrayBufferPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66B817B6B5AB00A7AE3F /* JSArrayBufferPrototype.cpp */; };
+		A3CA4A931BCD9DC9004C5B45 /* JSArrayBufferView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66BA17B6B5AB00A7AE3F /* JSArrayBufferView.cpp */; };
+		A3CA4A941BCD9DC9004C5B45 /* JSArrayIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7BDAEC417F4EA1400F6140C /* JSArrayIterator.cpp */; };
+		A3CA4A951BCD9DC9004C5B45 /* JSBase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1421359A0A677F4F00A8195E /* JSBase.cpp */; };
+		A3CA4A961BCD9DC9004C5B45 /* JSBoundFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86FA9E8F142BBB2D001773B7 /* JSBoundFunction.cpp */; };
+		A3CA4A971BCD9DC9004C5B45 /* JSCallbackConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1440F8AD0A508D200005F061 /* JSCallbackConstructor.cpp */; };
+		A3CA4A981BCD9DC9004C5B45 /* JSCallbackFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1440F8900A508B100005F061 /* JSCallbackFunction.cpp */; };
+		A3CA4A991BCD9DC9004C5B45 /* JSCallbackObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14ABDF5E0A437FEF00ECCA01 /* JSCallbackObject.cpp */; };
+		A3CA4A9A1BCD9DC9004C5B45 /* JSCell.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC7F8FBA0E19D1EF008632C0 /* JSCell.cpp */; };
+		A3CA4A9B1BCD9DC9004C5B45 /* JSCJSValue.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8870255597D01FF60F7 /* JSCJSValue.cpp */; };
+		A3CA4A9C1BCD9DC9004C5B45 /* JSClassRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1440FCE20A51E46B0005F061 /* JSClassRef.cpp */; };
+		A3CA4A9D1BCD9DC9004C5B45 /* JSContext.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E3C608167BAB87006D760A /* JSContext.mm */; };
+		A3CA4A9E1BCD9DC9004C5B45 /* JSContextRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14BD5A290A3E91F600BAF59C /* JSContextRef.cpp */; };
+		A3CA4A9F1BCD9DC9004C5B45 /* JSCTestRunnerUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A72028B41797601E0098028C /* JSCTestRunnerUtils.cpp */; };
+		A3CA4AA01BCD9DC9004C5B45 /* JSDataView.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66BD17B6B5AB00A7AE3F /* JSDataView.cpp */; };
+		A3CA4AA11BCD9DC9004C5B45 /* JSDataViewPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66BF17B6B5AB00A7AE3F /* JSDataViewPrototype.cpp */; };
+		A3CA4AA21BCD9DC9004C5B45 /* JSDateMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9788FC221471AD0C0068CE2D /* JSDateMath.cpp */; };
+		A3CA4AA31BCD9DC9004C5B45 /* JSFunction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A85E0255597D01FF60F7 /* JSFunction.cpp */; };
+		A3CA4AA41BCD9DC9004C5B45 /* JSGlobalObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14DE0D680D02431400AACCA2 /* JSGlobalObject.cpp */; };
+		A3CA4AA51BCD9DC9004C5B45 /* JSGlobalObjectFunctions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC756FC60E2031B200DE7D12 /* JSGlobalObjectFunctions.cpp */; };
+		A3CA4AA61BCD9DC9004C5B45 /* JSLock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65EA4C99092AF9E20093D800 /* JSLock.cpp */; };
+		A3CA4AA71BCD9DC9004C5B45 /* JSManagedValue.mm in Sources */ = {isa = PBXBuildFile; fileRef = C25D709916DE99F400FCA6BC /* JSManagedValue.mm */; };
+		A3CA4AA81BCD9DC9004C5B45 /* JSMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A700873F17CBE8EB00C3E643 /* JSMap.cpp */; };
+		A3CA4AA91BCD9DC9004C5B45 /* JSNameScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14874ADF15EBDE4A002E3587 /* JSNameScope.cpp */; };
+		A3CA4AAA1BCD9DC9004C5B45 /* JSNotAnObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A72700780DAC605600E548D7 /* JSNotAnObject.cpp */; };
+		A3CA4AAB1BCD9DC9004C5B45 /* JSObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC22A3980E16E14800AF21C8 /* JSObject.cpp */; };
+		A3CA4AAC1BCD9DC9004C5B45 /* JSObjectRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1482B7E20A43076000517CFC /* JSObjectRef.cpp */; };
+		A3CA4AAD1BCD9DC9004C5B45 /* JSONObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7F9935E0FD7325100A0B2D0 /* JSONObject.cpp */; };
+		A3CA4AAE1BCD9DC9004C5B45 /* JSProfilerPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95988BA90E477BEC00D28D4D /* JSProfilerPrivate.cpp */; };
+		A3CA4AAF1BCD9DC9004C5B45 /* JSPromise.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C184E1817BEDBD3007CB63A /* JSPromise.cpp */; };
+		A3CA4AB01BCD9DC9004C5B45 /* JSPromiseConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C184E2017BEE240007CB63A /* JSPromiseConstructor.cpp */; };
+		A3CA4AB11BCD9DC9004C5B45 /* JSPromisePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7C184E1C17BEE22E007CB63A /* JSPromisePrototype.cpp */; };
+		A3CA4AB21BCD9DC9004C5B45 /* JSPropertyNameIterator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A727FF660DA3053B00E548D7 /* JSPropertyNameIterator.cpp */; };
+		A3CA4AB31BCD9DC9004C5B45 /* JSProxy.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 862553CE16136AA5009F17D0 /* JSProxy.cpp */; };
+		A3CA4AB41BCD9DC9004C5B45 /* JSScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14874AE115EBDE4A002E3587 /* JSScope.cpp */; };
+		A3CA4AB51BCD9DC9004C5B45 /* JSScriptRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7C0C4AA167C08CD0017011D /* JSScriptRef.cpp */; };
+		A3CA4AB61BCD9DC9004C5B45 /* JSSegmentedVariableObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F919D0E157F3327004A4E7D /* JSSegmentedVariableObject.cpp */; };
+		A3CA4AB71BCD9DC9004C5B45 /* JSSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7299D9B17D12837005F5FF9 /* JSSet.cpp */; };
+		A3CA4AB81BCD9DC9004C5B45 /* JSStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D85B0ED218E900B89619 /* JSStack.cpp */; };
+		A3CA4AB91BCD9DC9004C5B45 /* JSString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9B60E1842FA000F9297 /* JSString.cpp */; };
+		A3CA4ABA1BCD9DC9004C5B45 /* JSStringJoiner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2600B5A4152BAAA70091EE5F /* JSStringJoiner.cpp */; };
+		A3CA4ABB1BCD9DC9004C5B45 /* ArrayBufferNeuteringWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FFC99D2184EE318009C10AB /* ArrayBufferNeuteringWatchpoint.cpp */; };
+		A3CA4ABC1BCD9DC9004C5B45 /* JSStringRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1482B74C0A43032800517CFC /* JSStringRef.cpp */; };
+		A3CA4ABD1BCD9DC9004C5B45 /* JSStringRefCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 146AAB370B66A94400E55F16 /* JSStringRefCF.cpp */; };
+		A3CA4ABE1BCD9DC9004C5B45 /* JSSymbolTableObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F919D09157EE09D004A4E7D /* JSSymbolTableObject.cpp */; };
+		A3CA4ABF1BCD9DC9004C5B45 /* JSTypedArrayConstructors.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66CC17B6B5AB00A7AE3F /* JSTypedArrayConstructors.cpp */; };
+		A3CA4AC01BCD9DC9004C5B45 /* InspectorJSTypeBuilders.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A532438518568317002ED692 /* InspectorJSTypeBuilders.cpp */; };
+		A3CA4AC11BCD9DC9004C5B45 /* JSTypedArrayPrototypes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66CE17B6B5AB00A7AE3F /* JSTypedArrayPrototypes.cpp */; };
+		A3CA4AC21BCD9DC9004C5B45 /* JSTypedArrays.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66D017B6B5AB00A7AE3F /* JSTypedArrays.cpp */; };
+		A3CA4AC31BCD9DC9004C5B45 /* JSValue.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E3C60D167BAB87006D760A /* JSValue.mm */; };
+		A3CA4AC41BCD9DC9004C5B45 /* JSValueRef.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14BD5A2B0A3E91F600BAF59C /* JSValueRef.cpp */; };
+		A3CA4AC51BCD9DC9004C5B45 /* JSVariableObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC22A39A0E16E14800AF21C8 /* JSVariableObject.cpp */; };
+		A3CA4AC61BCD9DC9004C5B45 /* JSVirtualMachine.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E3C610167BAB87006D760A /* JSVirtualMachine.mm */; };
+		A3CA4AC71BCD9DC9004C5B45 /* VMEntryScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE5932A5183C5A2600A1ECCC /* VMEntryScope.cpp */; };
+		A3CA4AC81BCD9DC9004C5B45 /* JSWeakMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7CA3AE117DA41AE006538AF /* JSWeakMap.cpp */; };
+		A3CA4AC91BCD9DC9004C5B45 /* JSWeakObjectMapRefPrivate.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7482B7A1166CDEA003B0712 /* JSWeakObjectMapRefPrivate.cpp */; };
+		A3CA4ACA1BCD9DC9004C5B45 /* JSWithScope.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1442565F15EDE98D0066A49B /* JSWithScope.cpp */; };
+		A3CA4ACB1BCD9DC9004C5B45 /* JSWrapperMap.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86E3C60B167BAB87006D760A /* JSWrapperMap.mm */; };
+		A3CA4ACC1BCD9DC9004C5B45 /* JSWrapperObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65C7A1710A8EAACB00FA37EA /* JSWrapperObject.cpp */; };
+		A3CA4ACD1BCD9DC9004C5B45 /* JumpTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCFD8C900EEB2EE700283848 /* JumpTable.cpp */; };
+		A3CA4ACE1BCD9DC9004C5B45 /* LazyOperandValueProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB5467814F5C468002C2989 /* LazyOperandValueProfile.cpp */; };
+		A3CA4ACF1BCD9DC9004C5B45 /* LegacyProfiler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95AB832E0DA42CAD00BC83F3 /* LegacyProfiler.cpp */; };
+		A3CA4AD01BCD9DC9004C5B45 /* Lexer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8650255597D01FF60F7 /* Lexer.cpp */; };
+		A3CA4AD11BCD9DC9004C5B45 /* LinkBuffer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4275615914A20004CB9FF /* LinkBuffer.cpp */; };
+		A3CA4AD21BCD9DC9004C5B45 /* LiteralParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E2EA6A0FB460CF00601F06 /* LiteralParser.cpp */; };
+		A3CA4AD31BCD9DC9004C5B45 /* LLIntCLoop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE20CE9B15F04A9500DF3430 /* LLIntCLoop.cpp */; };
+		A3CA4AD41BCD9DC9004C5B45 /* LLIntData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4680CE14BBB3D100BFE272 /* LLIntData.cpp */; };
+		A3CA4AD51BCD9DC9004C5B45 /* LLIntEntrypoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F38B00F17CF077F00B144D3 /* LLIntEntrypoint.cpp */; };
+		A3CA4AD61BCD9DC9004C5B45 /* LLIntExceptions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F46809D14BA7F8200BFE272 /* LLIntExceptions.cpp */; };
+		A3CA4AD71BCD9DC9004C5B45 /* LLIntSlowPaths.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F46809F14BA7F8200BFE272 /* LLIntSlowPaths.cpp */; settings = {COMPILER_FLAGS = "-Wno-unused-parameter"; }; };
+		A3CA4AD81BCD9DC9004C5B45 /* LLIntThunks.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0B839714BCF45A00885B4F /* LLIntThunks.cpp */; };
+		A3CA4AD91BCD9DC9004C5B45 /* LLVMAPI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FCEFAC71805E75500472CE4 /* LLVMAPI.cpp */; };
+		A3CA4ADA1BCD9DC9004C5B45 /* LLVMDisassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E5AB331799E4B200D2833D /* LLVMDisassembler.cpp */; };
+		A3CA4ADB1BCD9DC9004C5B45 /* Lookup.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8680255597D01FF60F7 /* Lookup.cpp */; };
+		A3CA4ADC1BCD9DC9004C5B45 /* LowLevelInterpreter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F4680C714BBB16900BFE272 /* LowLevelInterpreter.cpp */; };
+		A3CA4ADD1BCD9DC9004C5B45 /* MachineStackMarker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14B7233F12D7D0DA003BD5ED /* MachineStackMarker.cpp */; };
+		A3CA4ADE1BCD9DC9004C5B45 /* RemoteInspectorDebuggable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A594558E18245EDE00CC3843 /* RemoteInspectorDebuggable.cpp */; };
+		A3CA4ADF1BCD9DC9004C5B45 /* MacroAssembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FEB3ECE16237F6700AB67AD /* MacroAssembler.cpp */; };
+		A3CA4AE01BCD9DC9004C5B45 /* MacroAssemblerARM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86C568DD11A213EE0007F7F0 /* MacroAssemblerARM.cpp */; };
+		A3CA4AE11BCD9DC9004C5B45 /* MacroAssemblerARMv7.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A729009B17976C6000317298 /* MacroAssemblerARMv7.cpp */; };
+		A3CA4AE21BCD9DC9004C5B45 /* InspectorJSBackendDispatchers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A532438118568317002ED692 /* InspectorJSBackendDispatchers.cpp */; };
+		A3CA4AE31BCD9DC9004C5B45 /* MacroAssemblerX86Common.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7A4AE0717973B26005612B1 /* MacroAssemblerX86Common.cpp */; };
+		A3CA4AE41BCD9DC9004C5B45 /* MapConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A700873717CBE85300C3E643 /* MapConstructor.cpp */; };
+		A3CA4AE51BCD9DC9004C5B45 /* MapData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A78507D417CBC6FD0011F6E7 /* MapData.cpp */; };
+		A3CA4AE61BCD9DC9004C5B45 /* MapPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A700873B17CBE8D300C3E643 /* MapPrototype.cpp */; };
+		A3CA4AE71BCD9DC9004C5B45 /* MarkedAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2B916C414DA040C00CBAC86 /* MarkedAllocator.cpp */; };
+		A3CA4AE81BCD9DC9004C5B45 /* MarkedBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 142D6F0613539A2800B02E86 /* MarkedBlock.cpp */; };
+		A3CA4AE91BCD9DC9004C5B45 /* MarkedSpace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D2F3D8139F4BE200491031 /* MarkedSpace.cpp */; };
+		A3CA4AEA1BCD9DC9004C5B45 /* MarkStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 142D6F0E13539A4100B02E86 /* MarkStack.cpp */; };
+		A3CA4AEB1BCD9DC9004C5B45 /* MathObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A86A0255597D01FF60F7 /* MathObject.cpp */; };
+		A3CA4AEC1BCD9DC9004C5B45 /* MemoryStatistics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 90213E3B123A40C200D422F3 /* MemoryStatistics.cpp */; };
+		A3CA4AED1BCD9DC9004C5B45 /* MethodOfGettingAValueProfile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB5467C14F5CFD3002C2989 /* MethodOfGettingAValueProfile.cpp */; };
+		A3CA4AEE1BCD9DC9004C5B45 /* NameConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EBF2F91560F036008E9222 /* NameConstructor.cpp */; };
+		A3CA4AEF1BCD9DC9004C5B45 /* NameInstance.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EBF2FB1560F036008E9222 /* NameInstance.cpp */; };
+		A3CA4AF01BCD9DC9004C5B45 /* NamePrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86EBF2FD1560F036008E9222 /* NamePrototype.cpp */; };
+		A3CA4AF11BCD9DC9004C5B45 /* ScriptObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A54CF2F7184EAEDA00237F19 /* ScriptObject.cpp */; };
+		A3CA4AF21BCD9DC9004C5B45 /* NativeErrorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E9080E1839DB000F9297 /* NativeErrorConstructor.cpp */; };
+		A3CA4AF31BCD9DC9004C5B45 /* NativeErrorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC02E90A0E1839DB000F9297 /* NativeErrorPrototype.cpp */; };
+		A3CA4AF41BCD9DC9004C5B45 /* Nodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A86D0255597D01FF60F7 /* Nodes.cpp */; };
+		A3CA4AF51BCD9DC9004C5B45 /* NodesCodegen.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 655EB29A10CE2581001A990E /* NodesCodegen.cpp */; };
+		A3CA4AF61BCD9DC9004C5B45 /* NumberConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C20E16D4E900A06E92 /* NumberConstructor.cpp */; };
+		A3CA4AF71BCD9DC9004C5B45 /* NumberObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8700255597D01FF60F7 /* NumberObject.cpp */; };
+		A3CA4AF81BCD9DC9004C5B45 /* NumberPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C40E16D4E900A06E92 /* NumberPrototype.cpp */; };
+		A3CA4AF91BCD9DC9004C5B45 /* ObjCCallbackFunction.mm in Sources */ = {isa = PBXBuildFile; fileRef = 86F3EEBA168CCF750077B92A /* ObjCCallbackFunction.mm */; };
+		A3CA4AFA1BCD9DC9004C5B45 /* ObjectConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C60E16D4E900A06E92 /* ObjectConstructor.cpp */; };
+		A3CA4AFB1BCD9DC9004C5B45 /* ObjectPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC2680C80E16D4E900A06E92 /* ObjectPrototype.cpp */; };
+		A3CA4AFC1BCD9DC9004C5B45 /* OpaqueJSString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E124A8F60E555775003091F1 /* OpaqueJSString.cpp */; };
+		A3CA4AFD1BCD9DC9004C5B45 /* Opcode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 969A07940ED1D3AE00F1F681 /* Opcode.cpp */; };
+		A3CA4AFE1BCD9DC9004C5B45 /* Operations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A8770255597D01FF60F7 /* Operations.cpp */; };
+		A3CA4AFF1BCD9DC9004C5B45 /* Options.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FE228EA1436AB2300196C48 /* Options.cpp */; };
+		A3CA4B001BCD9DC9004C5B45 /* DFGSSALoweringPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC20CB718556A3500C9E954 /* DFGSSALoweringPhase.cpp */; };
+		A3CA4B011BCD9DC9004C5B45 /* Parser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93F0B3A909BB4DC00068FCE3 /* Parser.cpp */; };
+		A3CA4B021BCD9DC9004C5B45 /* ParserArena.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93052C320FB792190048FDC3 /* ParserArena.cpp */; };
+		A3CA4B031BCD9DC9004C5B45 /* PolymorphicPutByIdList.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9FC8BF14E1B5FB00D52AE0 /* PolymorphicPutByIdList.cpp */; };
+		A3CA4B041BCD9DC9004C5B45 /* PreciseJumpTargets.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F98205D16BFE37F00240D02 /* PreciseJumpTargets.cpp */; };
+		A3CA4B051BCD9DC9004C5B45 /* Profile.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95742F630DD11F5A000917FB /* Profile.cpp */; };
+		A3CA4B061BCD9DC9004C5B45 /* ProfiledCodeBlockJettisoningWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC97F31182020D7002C9B26 /* ProfiledCodeBlockJettisoningWatchpoint.cpp */; };
+		A3CA4B071BCD9DC9004C5B45 /* ProfileGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95CD45740E1C4FDD0085358E /* ProfileGenerator.cpp */; };
+		A3CA4B081BCD9DC9004C5B45 /* ProfileNode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 95AB83540DA43B4400BC83F3 /* ProfileNode.cpp */; };
+		A3CA4B091BCD9DC9004C5B45 /* ProfilerBytecode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF72992166AD347000F5BA3 /* ProfilerBytecode.cpp */; };
+		A3CA4B0A1BCD9DC9004C5B45 /* ProfilerBytecodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF72994166AD347000F5BA3 /* ProfilerBytecodes.cpp */; };
+		A3CA4B0B1BCD9DC9004C5B45 /* ProfilerBytecodeSequence.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F13912416771C30009CCB07 /* ProfilerBytecodeSequence.cpp */; };
+		A3CA4B0C1BCD9DC9004C5B45 /* ProfilerCompilation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF72996166AD347000F5BA3 /* ProfilerCompilation.cpp */; };
+		A3CA4B0D1BCD9DC9004C5B45 /* ProfilerCompilationKind.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF72998166AD347000F5BA3 /* ProfilerCompilationKind.cpp */; };
+		A3CA4B0E1BCD9DC9004C5B45 /* ProfilerCompiledBytecode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF7299A166AD347000F5BA3 /* ProfilerCompiledBytecode.cpp */; };
+		A3CA4B0F1BCD9DC9004C5B45 /* ProfilerDatabase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF7299C166AD347000F5BA3 /* ProfilerDatabase.cpp */; };
+		A3CA4B101BCD9DC9004C5B45 /* ProfilerOrigin.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF7299F166AD347000F5BA3 /* ProfilerOrigin.cpp */; };
+		A3CA4B111BCD9DC9004C5B45 /* ProfilerOriginStack.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF729A1166AD347000F5BA3 /* ProfilerOriginStack.cpp */; };
+		A3CA4B121BCD9DC9004C5B45 /* BytecodeBasicBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2FCAE0C17A9C24E0034C735 /* BytecodeBasicBlock.cpp */; };
+		A3CA4B131BCD9DC9004C5B45 /* DFGResurrectionForValidationPhase.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F666ECA1836B37E00D017F1 /* DFGResurrectionForValidationPhase.cpp */; };
+		A3CA4B141BCD9DC9004C5B45 /* ProfilerOSRExit.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB105871675482E00F8AB6E /* ProfilerOSRExit.cpp */; };
+		A3CA4B151BCD9DC9004C5B45 /* ProfilerOSRExitSite.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FB105891675482E00F8AB6E /* ProfilerOSRExitSite.cpp */; };
+		A3CA4B161BCD9DC9004C5B45 /* ProfilerProfiledBytecodes.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F13912616771C30009CCB07 /* ProfilerProfiledBytecodes.cpp */; };
+		A3CA4B171BCD9DC9004C5B45 /* PropertyDescriptor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7FB60A3103F7DC20017A286 /* PropertyDescriptor.cpp */; };
+		A3CA4B181BCD9DC9004C5B45 /* PropertyNameArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65400C0F0A69BAF200509887 /* PropertyNameArray.cpp */; };
+		A3CA4B191BCD9DC9004C5B45 /* PropertySlot.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 65621E6B089E859700760F35 /* PropertySlot.cpp */; };
+		A3CA4B1A1BCD9DC9004C5B45 /* PropertyTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = AD1CF06816DCAB2D00B97123 /* PropertyTable.cpp */; };
+		A3CA4B1B1BCD9DC9004C5B45 /* PrototypeMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14D844A216AA2C7000A65AF0 /* PrototypeMap.cpp */; };
+		A3CA4B1C1BCD9DC9004C5B45 /* PutByIdStatus.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F93329914CA7DC10085F3C6 /* PutByIdStatus.cpp */; };
+		A3CA4B1D1BCD9DC9004C5B45 /* ReduceWhitespace.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF60ABF16740F8100029779 /* ReduceWhitespace.cpp */; };
+		A3CA4B1E1BCD9DC9004C5B45 /* RegExp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A87D0255597D01FF60F7 /* RegExp.cpp */; };
+		A3CA4B1F1BCD9DC9004C5B45 /* RegExpCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A1712B3A11C7B212007A5315 /* RegExpCache.cpp */; };
+		A3CA4B201BCD9DC9004C5B45 /* RegExpCachedResult.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86F75EFB151C062F007C9BA3 /* RegExpCachedResult.cpp */; };
+		A3CA4B211BCD9DC9004C5B45 /* RegExpConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCD202BD0E1706A7002C7E82 /* RegExpConstructor.cpp */; };
+		A3CA4B221BCD9DC9004C5B45 /* RegExpMatchesArray.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86F75EFD151C062F007C9BA3 /* RegExpMatchesArray.cpp */; };
+		A3CA4B231BCD9DC9004C5B45 /* RegExpObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = F692A87B0255597D01FF60F7 /* RegExpObject.cpp */; };
+		A3CA4B241BCD9DC9004C5B45 /* RegExpPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCD202BF0E1706A7002C7E82 /* RegExpPrototype.cpp */; };
+		A3CA4B251BCD9DC9004C5B45 /* RegisterSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC3141418146D7000033232 /* RegisterSet.cpp */; };
+		A3CA4B261BCD9DC9004C5B45 /* Repatch.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E54917EE274900ABB217 /* Repatch.cpp */; };
+		A3CA4B271BCD9DC9004C5B45 /* SamplingCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F7700911402FF280078EB39 /* SamplingCounter.cpp */; };
+		A3CA4B281BCD9DC9004C5B45 /* SamplingTool.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1429D8830ED21C3D00B89619 /* SamplingTool.cpp */; };
+		A3CA4B291BCD9DC9004C5B45 /* SetConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7299DA317D12858005F5FF9 /* SetConstructor.cpp */; };
+		A3CA4B2A1BCD9DC9004C5B45 /* SetPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7299D9F17D12848005F5FF9 /* SetPrototype.cpp */; };
+		A3CA4B2B1BCD9DC9004C5B45 /* SimpleTypedArrayController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66D617B6B5AB00A7AE3F /* SimpleTypedArrayController.cpp */; };
+		A3CA4B2C1BCD9DC9004C5B45 /* SetIteratorPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A790DD67182F499700588807 /* SetIteratorPrototype.cpp */; };
+		A3CA4B2D1BCD9DC9004C5B45 /* SlotVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C225494215F7DBAA0065E898 /* SlotVisitor.cpp */; };
+		A3CA4B2E1BCD9DC9004C5B45 /* SmallStrings.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93303FE80E6A72B500786E6A /* SmallStrings.cpp */; };
+		A3CA4B2F1BCD9DC9004C5B45 /* SourceCode.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F2B9D17306C8B007DBDA5 /* SourceCode.cpp */; };
+		A3CA4B301BCD9DC9004C5B45 /* SourceProvider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F493AF816D0CAD10084508B /* SourceProvider.cpp */; };
+		A3CA4B311BCD9DC9004C5B45 /* SourceProviderCache.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E49DC15512EF277200184A1F /* SourceProviderCache.cpp */; };
+		A3CA4B321BCD9DC9004C5B45 /* SparseArrayValueMap.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F0CD4C315F6B6B50032F1C0 /* SparseArrayValueMap.cpp */; };
+		A3CA4B331BCD9DC9004C5B45 /* SpecialPointer.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F5541AF1613C1FB00CE3E25 /* SpecialPointer.cpp */; };
+		A3CA4B341BCD9DC9004C5B45 /* SpeculatedType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FD82E84141F3FDA00179C94 /* SpeculatedType.cpp */; };
+		A3CA4B351BCD9DC9004C5B45 /* StackVisitor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7C1EAEC17987AB600299DB2 /* StackVisitor.cpp */; };
+		A3CA4B361BCD9DC9004C5B45 /* StrictEvalActivation.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A730B6111250068F009D25B1 /* StrictEvalActivation.cpp */; };
+		A3CA4B371BCD9DC9004C5B45 /* StringConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC18C3C00E16EE3300B34460 /* StringConstructor.cpp */; };
+		A3CA4B381BCD9DC9004C5B45 /* StringObject.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC18C3C20E16EE3300B34460 /* StringObject.cpp */; };
+		A3CA4B391BCD9DC9004C5B45 /* StringPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BC18C3C50E16EE3300B34460 /* StringPrototype.cpp */; };
+		A3CA4B3A1BCD9DC9004C5B45 /* StringRecursionChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 93345A8712D838C400302BE3 /* StringRecursionChecker.cpp */; };
+		A3CA4B3B1BCD9DC9004C5B45 /* Structure.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCDE3AB00E6C82CF001453A7 /* Structure.cpp */; };
+		A3CA4B3C1BCD9DC9004C5B45 /* StructureChain.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 7E4EE70E0EBB7A5B005934AA /* StructureChain.cpp */; };
+		A3CA4B3D1BCD9DC9004C5B45 /* StructureRareData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2F0F2D016BAEEE900187C19 /* StructureRareData.cpp */; };
+		A3CA4B3E1BCD9DC9004C5B45 /* StructureStubClearingWatchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F766D3615AE4A1A008F363E /* StructureStubClearingWatchpoint.cpp */; };
+		A3CA4B3F1BCD9DC9004C5B45 /* StructureStubInfo.cpp in Sources */ = {isa = PBXBuildFile; fileRef = BCCF0D0B0EF0B8A500413C8F /* StructureStubInfo.cpp */; };
+		A3CA4B401BCD9DC9004C5B45 /* MapIteratorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A74DEF8B182D991400522C22 /* MapIteratorConstructor.cpp */; };
+		A3CA4B411BCD9DC9004C5B45 /* SuperRegion.cpp in Sources */ = {isa = PBXBuildFile; fileRef = C2DF442D1707AC0100A5CA96 /* SuperRegion.cpp */; };
+		A3CA4B421BCD9DC9004C5B45 /* SymbolTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F919D2715856770004A4E7D /* SymbolTable.cpp */; };
+		A3CA4B431BCD9DC9004C5B45 /* TempRegisterSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC314111814559100033232 /* TempRegisterSet.cpp */; };
+		A3CA4B441BCD9DC9004C5B45 /* TestRunnerUtils.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FA2C17917D7CF84009D015F /* TestRunnerUtils.cpp */; };
+		A3CA4B451BCD9DC9004C5B45 /* ThunkGenerators.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7386552118697B400540279 /* ThunkGenerators.cpp */; };
+		A3CA4B461BCD9DC9004C5B45 /* TypedArrayController.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66D917B6B5AB00A7AE3F /* TypedArrayController.cpp */; };
+		A3CA4B471BCD9DC9004C5B45 /* TypedArrayType.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F2B66DC17B6B5AB00A7AE3F /* TypedArrayType.cpp */; };
+		A3CA4B481BCD9DC9004C5B45 /* udis86.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4273E158EBD94004CB9FF /* udis86.c */; };
+		A3CA4B491BCD9DC9004C5B45 /* udis86_decode.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FF42734158EBD94004CB9FF /* udis86_decode.c */; };
+		A3CA4B4A1BCD9DC9004C5B45 /* SetIteratorConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A790DD65182F499700588807 /* SetIteratorConstructor.cpp */; };
+		A3CA4B4B1BCD9DC9004C5B45 /* udis86_input.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FF42737158EBD94004CB9FF /* udis86_input.c */; };
+		A3CA4B4C1BCD9DC9004C5B45 /* udis86_itab_holder.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4274C158EBFE1004CB9FF /* udis86_itab_holder.c */; };
+		A3CA4B4D1BCD9DC9004C5B45 /* udis86_syn-att.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FF42739158EBD94004CB9FF /* udis86_syn-att.c */; };
+		A3CA4B4E1BCD9DC9004C5B45 /* udis86_syn-intel.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4273A158EBD94004CB9FF /* udis86_syn-intel.c */; };
+		A3CA4B4F1BCD9DC9004C5B45 /* udis86_syn.c in Sources */ = {isa = PBXBuildFile; fileRef = 0FF4273B158EBD94004CB9FF /* udis86_syn.c */; };
+		A3CA4B501BCD9DC9004C5B45 /* UDis86Disassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FF42730158EBD44004CB9FF /* UDis86Disassembler.cpp */; };
+		A3CA4B511BCD9DC9004C5B45 /* UnlinkedCodeBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A79E781E15EECBA80047C855 /* UnlinkedCodeBlock.cpp */; };
+		A3CA4B521BCD9DC9004C5B45 /* ValueRecovery.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F24E55717F74EDB00ABB217 /* ValueRecovery.cpp */; };
+		A3CA4B531BCD9DC9004C5B45 /* VM.cpp in Sources */ = {isa = PBXBuildFile; fileRef = E18E3A570DF9278C00D90B34 /* VM.cpp */; };
+		A3CA4B541BCD9DC9004C5B45 /* VMInspector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FE4A331D15BD2E07006F54F3 /* VMInspector.cpp */; };
+		A3CA4B551BCD9DC9004C5B45 /* Watchdog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FED94F2B171E3E2300BE77A4 /* Watchdog.cpp */; };
+		A3CA4B561BCD9DC9004C5B45 /* WatchdogMac.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FED94F2D171E3E2300BE77A4 /* WatchdogMac.cpp */; };
+		A3CA4B571BCD9DC9004C5B45 /* DFGAvailability.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F666EC21835672B00D017F1 /* DFGAvailability.cpp */; };
+		A3CA4B581BCD9DC9004C5B45 /* Watchpoint.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F919D2215853CDE004A4E7D /* Watchpoint.cpp */; };
+		A3CA4B591BCD9DC9004C5B45 /* Weak.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1ACF7376171CA6FB00C9BB1E /* Weak.cpp */; };
+		A3CA4B5A1BCD9DC9004C5B45 /* WeakBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14E84F9914EE1ACC00D6D5D4 /* WeakBlock.cpp */; };
+		A3CA4B5B1BCD9DC9004C5B45 /* WeakHandleOwner.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14F7256314EE265E00B1652B /* WeakHandleOwner.cpp */; };
+		A3CA4B5C1BCD9DC9004C5B45 /* WeakMapConstructor.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7CA3ADD17DA41AE006538AF /* WeakMapConstructor.cpp */; };
+		A3CA4B5D1BCD9DC9004C5B45 /* WeakMapData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7CA3AE917DA5168006538AF /* WeakMapData.cpp */; };
+		A3CA4B5E1BCD9DC9004C5B45 /* WeakMapPrototype.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7CA3ADF17DA41AE006538AF /* WeakMapPrototype.cpp */; };
+		A3CA4B5F1BCD9DC9004C5B45 /* WeakSet.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 14E84F9B14EE1ACC00D6D5D4 /* WeakSet.cpp */; };
+		A3CA4B601BCD9DC9004C5B45 /* WriteBarrierSupport.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FC8150814043BCA00CFA603 /* WriteBarrierSupport.cpp */; };
+		A3CA4B611BCD9DC9004C5B45 /* RemoteInspector.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15E2182340B300A82E69 /* RemoteInspector.mm */; };
+		A3CA4B621BCD9DC9004C5B45 /* RemoteInspectorDebuggableConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15E5182340B300A82E69 /* RemoteInspectorDebuggableConnection.mm */; };
+		A3CA4B631BCD9DC9004C5B45 /* RemoteInspectorXPCConnection.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15E7182340B300A82E69 /* RemoteInspectorXPCConnection.mm */; };
+		A3CA4B641BCD9DC9004C5B45 /* X86Disassembler.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E5AB361799E4B200D2833D /* X86Disassembler.cpp */; };
+		A3CA4B651BCD9DC9004C5B45 /* YarrCanonicalizeUCS2.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 863C6D981521111200585E4E /* YarrCanonicalizeUCS2.cpp */; };
+		A3CA4B661BCD9DC9004C5B45 /* YarrInterpreter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86704B7D12DBA33700A9FE7B /* YarrInterpreter.cpp */; };
+		A3CA4B671BCD9DC9004C5B45 /* YarrJIT.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86704B7F12DBA33700A9FE7B /* YarrJIT.cpp */; };
+		A3CA4B681BCD9DC9004C5B45 /* YarrPattern.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86704B8212DBA33700A9FE7B /* YarrPattern.cpp */; };
+		A3CA4B691BCD9DC9004C5B45 /* InspectorAgentRegistry.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A593CF84184038CA00BFCE27 /* InspectorAgentRegistry.cpp */; };
+		A3CA4B6A1BCD9DC9004C5B45 /* YarrSyntaxChecker.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 86704B4012DB8A8100A9FE7B /* YarrSyntaxChecker.cpp */; };
+		A3CA4B6C1BCD9DC9004C5B45 /* CoreFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6560A4CF04B3B3E7008AE952 /* CoreFoundation.framework */; };
+		A3CA4B6D1BCD9DC9004C5B45 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 51F0EB6105C86C6B00E6DF1B /* Foundation.framework */; };
 		A513E5C7185F9446007E95AD /* InjectedScriptSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A513E5C6185F9436007E95AD /* InjectedScriptSource.h */; };
 		A532438718568335002ED692 /* InspectorJSBackendDispatchers.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A532438118568317002ED692 /* InspectorJSBackendDispatchers.cpp */; };
 		A532438818568335002ED692 /* InspectorJSBackendDispatchers.h in Headers */ = {isa = PBXBuildFile; fileRef = A532438218568317002ED692 /* InspectorJSBackendDispatchers.h */; settings = {ATTRIBUTES = (Private, ); }; };
@@ -2612,6 +3818,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 932F5B3E0822A1C700736975;
 			remoteInfo = "JavaScriptCore (Upgraded)";
+		};
+		A3CA46B31BCD9DC9004C5B45 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 0867D690FE84028FC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 10D592F61889C55E00C05A0D;
+			remoteInfo = "Derived Sources iOS";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -3498,6 +4711,8 @@
 		A1712B3A11C7B212007A5315 /* RegExpCache.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = RegExpCache.cpp; sourceTree = "<group>"; };
 		A1712B3E11C7B228007A5315 /* RegExpCache.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegExpCache.h; sourceTree = "<group>"; };
 		A1712B4011C7B235007A5315 /* RegExpKey.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = RegExpKey.h; sourceTree = "<group>"; };
+		A3B645F51BCDBA50001827C5 /* libWTF-tvOS.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = "libWTF-tvOS.a"; path = "../WTF/build/Debug-appletvos/libWTF-tvOS.a"; sourceTree = "<group>"; };
+		A3CA4B781BCD9DC9004C5B45 /* libJavaScriptCore-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libJavaScriptCore-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A513E5C6185F9436007E95AD /* InjectedScriptSource.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = InjectedScriptSource.h; sourceTree = "<group>"; };
 		A532438118568317002ED692 /* InspectorJSBackendDispatchers.cpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.cpp; path = InspectorJSBackendDispatchers.cpp; sourceTree = "<group>"; };
 		A532438218568317002ED692 /* InspectorJSBackendDispatchers.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = InspectorJSBackendDispatchers.h; sourceTree = "<group>"; };
@@ -4005,6 +5220,16 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A3CA4B6B1BCD9DC9004C5B45 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A3B645F61BCDBA50001827C5 /* libWTF-tvOS.a in Frameworks */,
+				A3CA4B6C1BCD9DC9004C5B45 /* CoreFoundation.framework in Frameworks */,
+				A3CA4B6D1BCD9DC9004C5B45 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -4020,6 +5245,7 @@
 				6511230514046A4C002B101D /* testRegExp */,
 				10D58E0C1889C1A000C05A0D /* libJSCLLIntOffsetsExtractor.a */,
 				10D592F41889C3DF00C05A0D /* libJavaScriptCore.a */,
+				A3CA4B781BCD9DC9004C5B45 /* libJavaScriptCore-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -4070,6 +5296,7 @@
 		0867D69AFE84028FC02AAC07 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				A3B645F51BCDBA50001827C5 /* libWTF-tvOS.a */,
 				6560A4CF04B3B3E7008AE952 /* CoreFoundation.framework */,
 				51F0EB6105C86C6B00E6DF1B /* Foundation.framework */,
 				A8A4748D151A8306004123FF /* libWTF.a */,
@@ -7074,6 +8301,736 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A3CA46B51BCD9DC9004C5B45 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A3CA46B61BCD9DC9004C5B45 /* A64DOpcode.h in Headers */,
+				A3CA46B71BCD9DC9004C5B45 /* AbstractMacroAssembler.h in Headers */,
+				A3CA46B81BCD9DC9004C5B45 /* JSTypedArray.h in Headers */,
+				A3CA46B91BCD9DC9004C5B45 /* AbstractPC.h in Headers */,
+				A3CA46BA1BCD9DC9004C5B45 /* APICallbackFunction.h in Headers */,
+				A3CA46BB1BCD9DC9004C5B45 /* APICast.h in Headers */,
+				A3CA46BC1BCD9DC9004C5B45 /* APIShims.h in Headers */,
+				A3CA46BD1BCD9DC9004C5B45 /* ArgList.h in Headers */,
+				A3CA46BE1BCD9DC9004C5B45 /* Arguments.h in Headers */,
+				A3CA46BF1BCD9DC9004C5B45 /* ArgumentsIteratorConstructor.h in Headers */,
+				A3CA46C01BCD9DC9004C5B45 /* ArgumentsIteratorPrototype.h in Headers */,
+				A3CA46C11BCD9DC9004C5B45 /* ARMAssembler.h in Headers */,
+				A3CA46C21BCD9DC9004C5B45 /* ARMv7Assembler.h in Headers */,
+				A3CA46C31BCD9DC9004C5B45 /* ARMv7DOpcode.h in Headers */,
+				A3CA46C41BCD9DC9004C5B45 /* CopyWriteBarrier.h in Headers */,
+				A3CA46C51BCD9DC9004C5B45 /* WriteBarrierBuffer.h in Headers */,
+				A3CA46C61BCD9DC9004C5B45 /* VMEntryScope.h in Headers */,
+				A3CA46C71BCD9DC9004C5B45 /* CodeGeneratorInspectorStrings.py in Headers */,
+				A3CA46C81BCD9DC9004C5B45 /* CodeGeneratorInspector.py in Headers */,
+				A3CA46C91BCD9DC9004C5B45 /* TempRegisterSet.h in Headers */,
+				A3CA46CA1BCD9DC9004C5B45 /* DFGFiltrationResult.h in Headers */,
+				A3CA46CB1BCD9DC9004C5B45 /* BytecodeBasicBlock.h in Headers */,
+				A3CA46CC1BCD9DC9004C5B45 /* generate-combined-inspector-json.py in Headers */,
+				A3CA46CD1BCD9DC9004C5B45 /* BytecodeLivenessAnalysis.h in Headers */,
+				A3CA46CE1BCD9DC9004C5B45 /* ArrayAllocationProfile.h in Headers */,
+				A3CA46CF1BCD9DC9004C5B45 /* Breakpoint.h in Headers */,
+				A3CA46D01BCD9DC9004C5B45 /* ArrayBuffer.h in Headers */,
+				A3CA46D11BCD9DC9004C5B45 /* DebuggerPrimitives.h in Headers */,
+				A3CA46D21BCD9DC9004C5B45 /* ArrayBufferView.h in Headers */,
+				A3CA46D31BCD9DC9004C5B45 /* ArrayConstructor.h in Headers */,
+				A3CA46D41BCD9DC9004C5B45 /* ArrayConventions.h in Headers */,
+				A3CA46D51BCD9DC9004C5B45 /* ArrayIteratorConstructor.h in Headers */,
+				A3CA46D61BCD9DC9004C5B45 /* ArrayIteratorPrototype.h in Headers */,
+				A3CA46D71BCD9DC9004C5B45 /* ArrayProfile.h in Headers */,
+				A3CA46D81BCD9DC9004C5B45 /* ArrayPrototype.h in Headers */,
+				A3CA46D91BCD9DC9004C5B45 /* ArrayPrototype.lut.h in Headers */,
+				A3CA46DA1BCD9DC9004C5B45 /* ArrayStorage.h in Headers */,
+				A3CA46DB1BCD9DC9004C5B45 /* AssemblerBuffer.h in Headers */,
+				A3CA46DC1BCD9DC9004C5B45 /* AssemblerBufferWithConstantPool.h in Headers */,
+				A3CA46DD1BCD9DC9004C5B45 /* AssemblyHelpers.h in Headers */,
+				A3CA46DE1BCD9DC9004C5B45 /* ASTBuilder.h in Headers */,
+				A3CA46DF1BCD9DC9004C5B45 /* BatchedTransitionOptimizer.h in Headers */,
+				A3CA46E01BCD9DC9004C5B45 /* BigInteger.h in Headers */,
+				A3CA46E11BCD9DC9004C5B45 /* BlockAllocator.h in Headers */,
+				A3CA46E21BCD9DC9004C5B45 /* BooleanObject.h in Headers */,
+				A3CA46E31BCD9DC9004C5B45 /* RemoteInspectorConstants.h in Headers */,
+				A3CA46E41BCD9DC9004C5B45 /* Butterfly.h in Headers */,
+				A3CA46E51BCD9DC9004C5B45 /* ButterflyInlines.h in Headers */,
+				A3CA46E61BCD9DC9004C5B45 /* BytecodeConventions.h in Headers */,
+				A3CA46E71BCD9DC9004C5B45 /* BytecodeGenerator.h in Headers */,
+				A3CA46E81BCD9DC9004C5B45 /* ByValInfo.h in Headers */,
+				A3CA46E91BCD9DC9004C5B45 /* CallData.h in Headers */,
+				A3CA46EA1BCD9DC9004C5B45 /* CallFrame.h in Headers */,
+				A3CA46EB1BCD9DC9004C5B45 /* CallFrameInlines.h in Headers */,
+				A3CA46EC1BCD9DC9004C5B45 /* CallIdentifier.h in Headers */,
+				A3CA46ED1BCD9DC9004C5B45 /* CallLinkInfo.h in Headers */,
+				A3CA46EE1BCD9DC9004C5B45 /* CallLinkStatus.h in Headers */,
+				A3CA46EF1BCD9DC9004C5B45 /* CallReturnOffsetToBytecodeOffset.h in Headers */,
+				A3CA46F01BCD9DC9004C5B45 /* CCallHelpers.h in Headers */,
+				A3CA46F11BCD9DC9004C5B45 /* ClassInfo.h in Headers */,
+				A3CA46F21BCD9DC9004C5B45 /* ClosureCallStubRoutine.h in Headers */,
+				A3CA46F31BCD9DC9004C5B45 /* CodeBlock.h in Headers */,
+				A3CA46F41BCD9DC9004C5B45 /* CodeBlockHash.h in Headers */,
+				A3CA46F51BCD9DC9004C5B45 /* CodeBlockJettisoningWatchpoint.h in Headers */,
+				A3CA46F61BCD9DC9004C5B45 /* CodeBlockSet.h in Headers */,
+				A3CA46F71BCD9DC9004C5B45 /* CodeBlockWithJITType.h in Headers */,
+				A3CA46F81BCD9DC9004C5B45 /* CodeCache.h in Headers */,
+				A3CA46F91BCD9DC9004C5B45 /* CodeLocation.h in Headers */,
+				A3CA46FA1BCD9DC9004C5B45 /* CodeOrigin.h in Headers */,
+				A3CA46FB1BCD9DC9004C5B45 /* CodeSpecializationKind.h in Headers */,
+				A3CA46FC1BCD9DC9004C5B45 /* CodeType.h in Headers */,
+				A3CA46FD1BCD9DC9004C5B45 /* CommonIdentifiers.h in Headers */,
+				A3CA46FE1BCD9DC9004C5B45 /* CommonSlowPaths.h in Headers */,
+				A3CA46FF1BCD9DC9004C5B45 /* CommonSlowPathsExceptions.h in Headers */,
+				A3CA47001BCD9DC9004C5B45 /* CompactJITCodeMap.h in Headers */,
+				A3CA47011BCD9DC9004C5B45 /* CompilationResult.h in Headers */,
+				A3CA47021BCD9DC9004C5B45 /* Completion.h in Headers */,
+				A3CA47031BCD9DC9004C5B45 /* ConcurrentJITLock.h in Headers */,
+				A3CA47041BCD9DC9004C5B45 /* config.h in Headers */,
+				A3CA47051BCD9DC9004C5B45 /* ConservativeRoots.h in Headers */,
+				A3CA47061BCD9DC9004C5B45 /* ConstructData.h in Headers */,
+				A3CA47071BCD9DC9004C5B45 /* CopiedAllocator.h in Headers */,
+				A3CA47081BCD9DC9004C5B45 /* CopiedBlock.h in Headers */,
+				A3CA47091BCD9DC9004C5B45 /* CopiedBlockInlines.h in Headers */,
+				A3CA470A1BCD9DC9004C5B45 /* CopiedSpace.h in Headers */,
+				A3CA470B1BCD9DC9004C5B45 /* CopiedSpaceInlines.h in Headers */,
+				A3CA470C1BCD9DC9004C5B45 /* CopyToken.h in Headers */,
+				A3CA470D1BCD9DC9004C5B45 /* CopyVisitor.h in Headers */,
+				A3CA470E1BCD9DC9004C5B45 /* CopyVisitorInlines.h in Headers */,
+				A3CA470F1BCD9DC9004C5B45 /* CopyWorkList.h in Headers */,
+				A3CA47101BCD9DC9004C5B45 /* create_hash_table in Headers */,
+				A3CA47111BCD9DC9004C5B45 /* DataFormat.h in Headers */,
+				A3CA47121BCD9DC9004C5B45 /* DataView.h in Headers */,
+				A3CA47131BCD9DC9004C5B45 /* DateConstructor.h in Headers */,
+				A3CA47141BCD9DC9004C5B45 /* DateConversion.h in Headers */,
+				A3CA47151BCD9DC9004C5B45 /* InspectorAgentBase.h in Headers */,
+				A3CA47161BCD9DC9004C5B45 /* DateInstance.h in Headers */,
+				A3CA47171BCD9DC9004C5B45 /* DateInstanceCache.h in Headers */,
+				A3CA47181BCD9DC9004C5B45 /* DatePrototype.h in Headers */,
+				A3CA47191BCD9DC9004C5B45 /* DatePrototype.lut.h in Headers */,
+				A3CA471A1BCD9DC9004C5B45 /* Debugger.h in Headers */,
+				A3CA471B1BCD9DC9004C5B45 /* DebuggerActivation.h in Headers */,
+				A3CA471C1BCD9DC9004C5B45 /* DebuggerCallFrame.h in Headers */,
+				A3CA471D1BCD9DC9004C5B45 /* DeferGC.h in Headers */,
+				A3CA471E1BCD9DC9004C5B45 /* BytecodeUseDef.h in Headers */,
+				A3CA471F1BCD9DC9004C5B45 /* DeferredCompilationCallback.h in Headers */,
+				A3CA47201BCD9DC9004C5B45 /* DFGAbstractHeap.h in Headers */,
+				A3CA47211BCD9DC9004C5B45 /* DFGAbstractInterpreter.h in Headers */,
+				A3CA47221BCD9DC9004C5B45 /* DFGAbstractInterpreterInlines.h in Headers */,
+				A3CA47231BCD9DC9004C5B45 /* DFGAbstractValue.h in Headers */,
+				A3CA47241BCD9DC9004C5B45 /* DFGAdjacencyList.h in Headers */,
+				A3CA47251BCD9DC9004C5B45 /* DFGAllocator.h in Headers */,
+				A3CA47261BCD9DC9004C5B45 /* DFGAnalysis.h in Headers */,
+				A3CA47271BCD9DC9004C5B45 /* DFGArgumentPosition.h in Headers */,
+				A3CA47281BCD9DC9004C5B45 /* DFGArgumentsSimplificationPhase.h in Headers */,
+				A3CA47291BCD9DC9004C5B45 /* DFGArrayifySlowPathGenerator.h in Headers */,
+				A3CA472A1BCD9DC9004C5B45 /* DFGArrayMode.h in Headers */,
+				A3CA472B1BCD9DC9004C5B45 /* RemoteInspectorDebuggableConnection.h in Headers */,
+				A3CA472C1BCD9DC9004C5B45 /* DFGAtTailAbstractState.h in Headers */,
+				A3CA472D1BCD9DC9004C5B45 /* DFGBackwardsPropagationPhase.h in Headers */,
+				A3CA472E1BCD9DC9004C5B45 /* DFGBasicBlock.h in Headers */,
+				A3CA472F1BCD9DC9004C5B45 /* DFGBasicBlockInlines.h in Headers */,
+				A3CA47301BCD9DC9004C5B45 /* DFGBinarySwitch.h in Headers */,
+				A3CA47311BCD9DC9004C5B45 /* DFGBlockInsertionSet.h in Headers */,
+				A3CA47321BCD9DC9004C5B45 /* DFGBranchDirection.h in Headers */,
+				A3CA47331BCD9DC9004C5B45 /* MacroAssemblerARM64.h in Headers */,
+				A3CA47341BCD9DC9004C5B45 /* DFGByteCodeParser.h in Headers */,
+				A3CA47351BCD9DC9004C5B45 /* InspectorAgentRegistry.h in Headers */,
+				A3CA47361BCD9DC9004C5B45 /* DFGCallArrayAllocatorSlowPathGenerator.h in Headers */,
+				A3CA47371BCD9DC9004C5B45 /* DFGCapabilities.h in Headers */,
+				A3CA47381BCD9DC9004C5B45 /* DFGCFAPhase.h in Headers */,
+				A3CA47391BCD9DC9004C5B45 /* DFGCFGSimplificationPhase.h in Headers */,
+				A3CA473A1BCD9DC9004C5B45 /* DFGClobberize.h in Headers */,
+				A3CA473B1BCD9DC9004C5B45 /* DFGClobberSet.h in Headers */,
+				A3CA473C1BCD9DC9004C5B45 /* DFGCommon.h in Headers */,
+				A3CA473D1BCD9DC9004C5B45 /* DFGCommonData.h in Headers */,
+				A3CA473E1BCD9DC9004C5B45 /* DFGCompilationKey.h in Headers */,
+				A3CA473F1BCD9DC9004C5B45 /* DFGCompilationMode.h in Headers */,
+				A3CA47401BCD9DC9004C5B45 /* DFGConstantFoldingPhase.h in Headers */,
+				A3CA47411BCD9DC9004C5B45 /* DFGCPSRethreadingPhase.h in Headers */,
+				A3CA47421BCD9DC9004C5B45 /* DFGCriticalEdgeBreakingPhase.h in Headers */,
+				A3CA47431BCD9DC9004C5B45 /* DFGCSEPhase.h in Headers */,
+				A3CA47441BCD9DC9004C5B45 /* DFGDCEPhase.h in Headers */,
+				A3CA47451BCD9DC9004C5B45 /* DFGDesiredIdentifiers.h in Headers */,
+				A3CA47461BCD9DC9004C5B45 /* DFGDesiredStructureChains.h in Headers */,
+				A3CA47471BCD9DC9004C5B45 /* DFGDesiredTransitions.h in Headers */,
+				A3CA47481BCD9DC9004C5B45 /* DFGDesiredWatchpoints.h in Headers */,
+				A3CA47491BCD9DC9004C5B45 /* DFGSSALoweringPhase.h in Headers */,
+				A3CA474A1BCD9DC9004C5B45 /* DFGDesiredWeakReferences.h in Headers */,
+				A3CA474B1BCD9DC9004C5B45 /* DFGDesiredWriteBarriers.h in Headers */,
+				A3CA474C1BCD9DC9004C5B45 /* DFGDisassembler.h in Headers */,
+				A3CA474D1BCD9DC9004C5B45 /* DFGDominators.h in Headers */,
+				A3CA474E1BCD9DC9004C5B45 /* DFGDoubleFormatState.h in Headers */,
+				A3CA474F1BCD9DC9004C5B45 /* DFGDriver.h in Headers */,
+				A3CA47501BCD9DC9004C5B45 /* DFGEdge.h in Headers */,
+				A3CA47511BCD9DC9004C5B45 /* DFGEdgeDominates.h in Headers */,
+				A3CA47521BCD9DC9004C5B45 /* DFGEdgeUsesStructure.h in Headers */,
+				A3CA47531BCD9DC9004C5B45 /* DFGExitProfile.h in Headers */,
+				A3CA47541BCD9DC9004C5B45 /* DFGFailedFinalizer.h in Headers */,
+				A3CA47551BCD9DC9004C5B45 /* DFGFinalizer.h in Headers */,
+				A3CA47561BCD9DC9004C5B45 /* DFGFixupPhase.h in Headers */,
+				A3CA47571BCD9DC9004C5B45 /* DFGFlushedAt.h in Headers */,
+				A3CA47581BCD9DC9004C5B45 /* DFGFlushFormat.h in Headers */,
+				A3CA47591BCD9DC9004C5B45 /* DFGFlushLivenessAnalysisPhase.h in Headers */,
+				A3CA475A1BCD9DC9004C5B45 /* DFGGenerationInfo.h in Headers */,
+				A3CA475B1BCD9DC9004C5B45 /* DFGGraph.h in Headers */,
+				A3CA475C1BCD9DC9004C5B45 /* DFGInlineCacheWrapper.h in Headers */,
+				A3CA475D1BCD9DC9004C5B45 /* DFGInlineCacheWrapperInlines.h in Headers */,
+				A3CA475E1BCD9DC9004C5B45 /* DFGInPlaceAbstractState.h in Headers */,
+				A3CA475F1BCD9DC9004C5B45 /* DFGInsertionSet.h in Headers */,
+				A3CA47601BCD9DC9004C5B45 /* DFGInvalidationPointInjectionPhase.h in Headers */,
+				A3CA47611BCD9DC9004C5B45 /* DFGJITCode.h in Headers */,
+				A3CA47621BCD9DC9004C5B45 /* DFGJITCompiler.h in Headers */,
+				A3CA47631BCD9DC9004C5B45 /* DFGJITFinalizer.h in Headers */,
+				A3CA47641BCD9DC9004C5B45 /* DFGJumpReplacement.h in Headers */,
+				A3CA47651BCD9DC9004C5B45 /* DFGLazyJSValue.h in Headers */,
+				A3CA47661BCD9DC9004C5B45 /* DFGLICMPhase.h in Headers */,
+				A3CA47671BCD9DC9004C5B45 /* DFGLivenessAnalysisPhase.h in Headers */,
+				A3CA47681BCD9DC9004C5B45 /* DFGLongLivedState.h in Headers */,
+				A3CA47691BCD9DC9004C5B45 /* DFGLoopPreHeaderCreationPhase.h in Headers */,
+				A3CA476A1BCD9DC9004C5B45 /* DFGMergeMode.h in Headers */,
+				A3CA476B1BCD9DC9004C5B45 /* DFGMinifiedGraph.h in Headers */,
+				A3CA476C1BCD9DC9004C5B45 /* DFGMinifiedID.h in Headers */,
+				A3CA476D1BCD9DC9004C5B45 /* DFGMinifiedNode.h in Headers */,
+				A3CA476E1BCD9DC9004C5B45 /* DFGNaturalLoops.h in Headers */,
+				A3CA476F1BCD9DC9004C5B45 /* DFGNode.h in Headers */,
+				A3CA47701BCD9DC9004C5B45 /* DFGNodeAllocator.h in Headers */,
+				A3CA47711BCD9DC9004C5B45 /* DFGNodeFlags.h in Headers */,
+				A3CA47721BCD9DC9004C5B45 /* DFGNodeType.h in Headers */,
+				A3CA47731BCD9DC9004C5B45 /* DFGOperations.h in Headers */,
+				A3CA47741BCD9DC9004C5B45 /* DFGOSRAvailabilityAnalysisPhase.h in Headers */,
+				A3CA47751BCD9DC9004C5B45 /* DFGOSREntry.h in Headers */,
+				A3CA47761BCD9DC9004C5B45 /* DFGOSREntrypointCreationPhase.h in Headers */,
+				A3CA47771BCD9DC9004C5B45 /* DFGOSRExit.h in Headers */,
+				A3CA47781BCD9DC9004C5B45 /* ConstantMode.h in Headers */,
+				A3CA47791BCD9DC9004C5B45 /* DFGOSRExitBase.h in Headers */,
+				A3CA477A1BCD9DC9004C5B45 /* RemoteInspectorXPCConnection.h in Headers */,
+				A3CA477B1BCD9DC9004C5B45 /* DFGOSRExitCompilationInfo.h in Headers */,
+				A3CA477C1BCD9DC9004C5B45 /* DFGOSRExitCompiler.h in Headers */,
+				A3CA477D1BCD9DC9004C5B45 /* DFGOSRExitCompilerCommon.h in Headers */,
+				A3CA477E1BCD9DC9004C5B45 /* DFGOSRExitJumpPlaceholder.h in Headers */,
+				A3CA477F1BCD9DC9004C5B45 /* DFGOSRExitPreparation.h in Headers */,
+				A3CA47801BCD9DC9004C5B45 /* DFGPhase.h in Headers */,
+				A3CA47811BCD9DC9004C5B45 /* DFGPlan.h in Headers */,
+				A3CA47821BCD9DC9004C5B45 /* DFGPredictionInjectionPhase.h in Headers */,
+				A3CA47831BCD9DC9004C5B45 /* DFGPredictionPropagationPhase.h in Headers */,
+				A3CA47841BCD9DC9004C5B45 /* DFGRegisterBank.h in Headers */,
+				A3CA47851BCD9DC9004C5B45 /* DFGSafeToExecute.h in Headers */,
+				A3CA47861BCD9DC9004C5B45 /* DFGSaneStringGetByValSlowPathGenerator.h in Headers */,
+				A3CA47871BCD9DC9004C5B45 /* DFGScoreBoard.h in Headers */,
+				A3CA47881BCD9DC9004C5B45 /* DFGSilentRegisterSavePlan.h in Headers */,
+				A3CA47891BCD9DC9004C5B45 /* DFGSlowPathGenerator.h in Headers */,
+				A3CA478A1BCD9DC9004C5B45 /* DFGSpeculativeJIT.h in Headers */,
+				A3CA478B1BCD9DC9004C5B45 /* DFGSSAConversionPhase.h in Headers */,
+				A3CA478C1BCD9DC9004C5B45 /* DFGStackLayoutPhase.h in Headers */,
+				A3CA478D1BCD9DC9004C5B45 /* InspectorValues.h in Headers */,
+				A3CA478E1BCD9DC9004C5B45 /* DFGStructureAbstractValue.h in Headers */,
+				A3CA478F1BCD9DC9004C5B45 /* DFGThunks.h in Headers */,
+				A3CA47901BCD9DC9004C5B45 /* DFGTierUpCheckInjectionPhase.h in Headers */,
+				A3CA47911BCD9DC9004C5B45 /* DFGToFTLDeferredCompilationCallback.h in Headers */,
+				A3CA47921BCD9DC9004C5B45 /* VariableWatchpointSet.h in Headers */,
+				A3CA47931BCD9DC9004C5B45 /* DFGToFTLForOSREntryDeferredCompilationCallback.h in Headers */,
+				A3CA47941BCD9DC9004C5B45 /* DFGTypeCheckHoistingPhase.h in Headers */,
+				A3CA47951BCD9DC9004C5B45 /* DFGUnificationPhase.h in Headers */,
+				A3CA47961BCD9DC9004C5B45 /* DFGUseKind.h in Headers */,
+				A3CA47971BCD9DC9004C5B45 /* DFGValidate.h in Headers */,
+				A3CA47981BCD9DC9004C5B45 /* DFGValueRecoveryOverride.h in Headers */,
+				A3CA47991BCD9DC9004C5B45 /* DFGValueSource.h in Headers */,
+				A3CA479A1BCD9DC9004C5B45 /* DFGVariableAccessData.h in Headers */,
+				A3CA479B1BCD9DC9004C5B45 /* DFGVariableAccessDataDump.h in Headers */,
+				A3CA479C1BCD9DC9004C5B45 /* DFGVariableEvent.h in Headers */,
+				A3CA479D1BCD9DC9004C5B45 /* DFGVariableEventStream.h in Headers */,
+				A3CA479E1BCD9DC9004C5B45 /* DFGVariadicFunction.h in Headers */,
+				A3CA479F1BCD9DC9004C5B45 /* DFGVirtualRegisterAllocationPhase.h in Headers */,
+				A3CA47A01BCD9DC9004C5B45 /* DFGWatchpointCollectionPhase.h in Headers */,
+				A3CA47A11BCD9DC9004C5B45 /* DFGWorklist.h in Headers */,
+				A3CA47A21BCD9DC9004C5B45 /* Disassembler.h in Headers */,
+				A3CA47A31BCD9DC9004C5B45 /* DumpContext.h in Headers */,
+				A3CA47A41BCD9DC9004C5B45 /* Error.h in Headers */,
+				A3CA47A51BCD9DC9004C5B45 /* ErrorConstructor.h in Headers */,
+				A3CA47A61BCD9DC9004C5B45 /* ErrorInstance.h in Headers */,
+				A3CA47A71BCD9DC9004C5B45 /* ErrorPrototype.h in Headers */,
+				A3CA47A81BCD9DC9004C5B45 /* EvalCodeCache.h in Headers */,
+				A3CA47A91BCD9DC9004C5B45 /* ExceptionHelpers.h in Headers */,
+				A3CA47AA1BCD9DC9004C5B45 /* Executable.h in Headers */,
+				A3CA47AB1BCD9DC9004C5B45 /* ExecutableAllocator.h in Headers */,
+				A3CA47AC1BCD9DC9004C5B45 /* ExecutionCounter.h in Headers */,
+				A3CA47AD1BCD9DC9004C5B45 /* ExitKind.h in Headers */,
+				A3CA47AE1BCD9DC9004C5B45 /* ExpressionRangeInfo.h in Headers */,
+				A3CA47AF1BCD9DC9004C5B45 /* Float32Array.h in Headers */,
+				A3CA47B01BCD9DC9004C5B45 /* ScriptValue.h in Headers */,
+				A3CA47B11BCD9DC9004C5B45 /* Float64Array.h in Headers */,
+				A3CA47B21BCD9DC9004C5B45 /* FPRInfo.h in Headers */,
+				A3CA47B31BCD9DC9004C5B45 /* ArrayBufferNeuteringWatchpoint.h in Headers */,
+				A3CA47B41BCD9DC9004C5B45 /* FTLAbbreviatedTypes.h in Headers */,
+				A3CA47B51BCD9DC9004C5B45 /* FTLAbbreviations.h in Headers */,
+				A3CA47B61BCD9DC9004C5B45 /* FTLAbstractHeap.h in Headers */,
+				A3CA47B71BCD9DC9004C5B45 /* FTLAbstractHeapRepository.h in Headers */,
+				A3CA47B81BCD9DC9004C5B45 /* JSGlobalObjectDebuggable.h in Headers */,
+				A3CA47B91BCD9DC9004C5B45 /* FTLCapabilities.h in Headers */,
+				A3CA47BA1BCD9DC9004C5B45 /* FTLCommonValues.h in Headers */,
+				A3CA47BB1BCD9DC9004C5B45 /* FTLCompile.h in Headers */,
+				A3CA47BC1BCD9DC9004C5B45 /* FTLExitArgument.h in Headers */,
+				A3CA47BD1BCD9DC9004C5B45 /* FTLExitArgumentForOperand.h in Headers */,
+				A3CA47BE1BCD9DC9004C5B45 /* FTLExitArgumentList.h in Headers */,
+				A3CA47BF1BCD9DC9004C5B45 /* FTLExitThunkGenerator.h in Headers */,
+				A3CA47C01BCD9DC9004C5B45 /* FTLExitValue.h in Headers */,
+				A3CA47C11BCD9DC9004C5B45 /* FTLFail.h in Headers */,
+				A3CA47C21BCD9DC9004C5B45 /* FTLFormattedValue.h in Headers */,
+				A3CA47C31BCD9DC9004C5B45 /* FTLForOSREntryJITCode.h in Headers */,
+				A3CA47C41BCD9DC9004C5B45 /* FTLGeneratedFunction.h in Headers */,
+				A3CA47C51BCD9DC9004C5B45 /* FTLInlineCacheDescriptor.h in Headers */,
+				A3CA47C61BCD9DC9004C5B45 /* FTLInlineCacheSize.h in Headers */,
+				A3CA47C71BCD9DC9004C5B45 /* FTLIntrinsicRepository.h in Headers */,
+				A3CA47C81BCD9DC9004C5B45 /* FTLJITCode.h in Headers */,
+				A3CA47C91BCD9DC9004C5B45 /* FTLJITFinalizer.h in Headers */,
+				A3CA47CA1BCD9DC9004C5B45 /* FTLLink.h in Headers */,
+				A3CA47CB1BCD9DC9004C5B45 /* FTLLocation.h in Headers */,
+				A3CA47CC1BCD9DC9004C5B45 /* FTLLowerDFGToLLVM.h in Headers */,
+				A3CA47CD1BCD9DC9004C5B45 /* FTLLoweredNodeValue.h in Headers */,
+				A3CA47CE1BCD9DC9004C5B45 /* FTLOSREntry.h in Headers */,
+				A3CA47CF1BCD9DC9004C5B45 /* FTLOSRExit.h in Headers */,
+				A3CA47D01BCD9DC9004C5B45 /* FTLOSRExitCompilationInfo.h in Headers */,
+				A3CA47D11BCD9DC9004C5B45 /* FTLOSRExitCompiler.h in Headers */,
+				A3CA47D21BCD9DC9004C5B45 /* FTLOutput.h in Headers */,
+				A3CA47D31BCD9DC9004C5B45 /* FTLSaveRestore.h in Headers */,
+				A3CA47D41BCD9DC9004C5B45 /* FTLSlowPathCall.h in Headers */,
+				A3CA47D51BCD9DC9004C5B45 /* FTLSlowPathCallKey.h in Headers */,
+				A3CA47D61BCD9DC9004C5B45 /* FTLStackMaps.h in Headers */,
+				A3CA47D71BCD9DC9004C5B45 /* FTLState.h in Headers */,
+				A3CA47D81BCD9DC9004C5B45 /* FTLSwitchCase.h in Headers */,
+				A3CA47D91BCD9DC9004C5B45 /* FTLThunks.h in Headers */,
+				A3CA47DA1BCD9DC9004C5B45 /* FTLTypedPointer.h in Headers */,
+				A3CA47DB1BCD9DC9004C5B45 /* FTLValueFormat.h in Headers */,
+				A3CA47DC1BCD9DC9004C5B45 /* FTLValueFromBlock.h in Headers */,
+				A3CA47DD1BCD9DC9004C5B45 /* FunctionConstructor.h in Headers */,
+				A3CA47DE1BCD9DC9004C5B45 /* FunctionExecutableDump.h in Headers */,
+				A3CA47DF1BCD9DC9004C5B45 /* FunctionPrototype.h in Headers */,
+				A3CA47E01BCD9DC9004C5B45 /* GCActivityCallback.h in Headers */,
+				A3CA47E11BCD9DC9004C5B45 /* GCAssertions.h in Headers */,
+				A3CA47E21BCD9DC9004C5B45 /* GCAwareJITStubRoutine.h in Headers */,
+				A3CA47E31BCD9DC9004C5B45 /* GCIncomingRefCounted.h in Headers */,
+				A3CA47E41BCD9DC9004C5B45 /* GCIncomingRefCountedInlines.h in Headers */,
+				A3CA47E51BCD9DC9004C5B45 /* GCIncomingRefCountedSet.h in Headers */,
+				A3CA47E61BCD9DC9004C5B45 /* GCIncomingRefCountedSetInlines.h in Headers */,
+				A3CA47E71BCD9DC9004C5B45 /* GCThread.h in Headers */,
+				A3CA47E81BCD9DC9004C5B45 /* GCThreadSharedData.h in Headers */,
+				A3CA47E91BCD9DC9004C5B45 /* GenericTypedArrayView.h in Headers */,
+				A3CA47EA1BCD9DC9004C5B45 /* GenericTypedArrayViewInlines.h in Headers */,
+				A3CA47EB1BCD9DC9004C5B45 /* GetByIdStatus.h in Headers */,
+				A3CA47EC1BCD9DC9004C5B45 /* GPRInfo.h in Headers */,
+				A3CA47ED1BCD9DC9004C5B45 /* Handle.h in Headers */,
+				A3CA47EE1BCD9DC9004C5B45 /* HandleBlock.h in Headers */,
+				A3CA47EF1BCD9DC9004C5B45 /* HandleBlockInlines.h in Headers */,
+				A3CA47F01BCD9DC9004C5B45 /* HandlerInfo.h in Headers */,
+				A3CA47F11BCD9DC9004C5B45 /* HandleSet.h in Headers */,
+				A3CA47F21BCD9DC9004C5B45 /* HandleStack.h in Headers */,
+				A3CA47F31BCD9DC9004C5B45 /* HandleTypes.h in Headers */,
+				A3CA47F41BCD9DC9004C5B45 /* Heap.h in Headers */,
+				A3CA47F51BCD9DC9004C5B45 /* HeapBlock.h in Headers */,
+				A3CA47F61BCD9DC9004C5B45 /* HeapIterationScope.h in Headers */,
+				A3CA47F71BCD9DC9004C5B45 /* HeapOperation.h in Headers */,
+				A3CA47F81BCD9DC9004C5B45 /* HeapRootVisitor.h in Headers */,
+				A3CA47F91BCD9DC9004C5B45 /* HeapStatistics.h in Headers */,
+				A3CA47FA1BCD9DC9004C5B45 /* FullBytecodeLiveness.h in Headers */,
+				A3CA47FB1BCD9DC9004C5B45 /* HeapTimer.h in Headers */,
+				A3CA47FC1BCD9DC9004C5B45 /* HostCallReturnValue.h in Headers */,
+				A3CA47FD1BCD9DC9004C5B45 /* Identifier.h in Headers */,
+				A3CA47FE1BCD9DC9004C5B45 /* IncrementalSweeper.h in Headers */,
+				A3CA47FF1BCD9DC9004C5B45 /* IndexingHeader.h in Headers */,
+				A3CA48001BCD9DC9004C5B45 /* IndexingHeaderInlines.h in Headers */,
+				A3CA48011BCD9DC9004C5B45 /* IndexingType.h in Headers */,
+				A3CA48021BCD9DC9004C5B45 /* InitializeLLVM.h in Headers */,
+				A3CA48031BCD9DC9004C5B45 /* InitializeLLVMPOSIX.h in Headers */,
+				A3CA48041BCD9DC9004C5B45 /* InitializeThreading.h in Headers */,
+				A3CA48051BCD9DC9004C5B45 /* InlineCallFrameSet.h in Headers */,
+				A3CA48061BCD9DC9004C5B45 /* Instruction.h in Headers */,
+				A3CA48071BCD9DC9004C5B45 /* Int16Array.h in Headers */,
+				A3CA48081BCD9DC9004C5B45 /* Int32Array.h in Headers */,
+				A3CA48091BCD9DC9004C5B45 /* Int8Array.h in Headers */,
+				A3CA480A1BCD9DC9004C5B45 /* IntendedStructureChain.h in Headers */,
+				A3CA480B1BCD9DC9004C5B45 /* InternalFunction.h in Headers */,
+				A3CA480C1BCD9DC9004C5B45 /* Interpreter.h in Headers */,
+				A3CA480D1BCD9DC9004C5B45 /* Intrinsic.h in Headers */,
+				A3CA480E1BCD9DC9004C5B45 /* JavaScript.h in Headers */,
+				A3CA480F1BCD9DC9004C5B45 /* JavaScriptCore.h in Headers */,
+				A3CA48101BCD9DC9004C5B45 /* JavaScriptCorePrefix.h in Headers */,
+				A3CA48111BCD9DC9004C5B45 /* JIT.h in Headers */,
+				A3CA48121BCD9DC9004C5B45 /* JITCode.h in Headers */,
+				A3CA48131BCD9DC9004C5B45 /* JITCompilationEffort.h in Headers */,
+				A3CA48141BCD9DC9004C5B45 /* JITDisassembler.h in Headers */,
+				A3CA48151BCD9DC9004C5B45 /* RemoteInspectorDebuggable.h in Headers */,
+				A3CA48161BCD9DC9004C5B45 /* JITExceptions.h in Headers */,
+				A3CA48171BCD9DC9004C5B45 /* DFGStrengthReductionPhase.h in Headers */,
+				A3CA48181BCD9DC9004C5B45 /* JITInlineCacheGenerator.h in Headers */,
+				A3CA48191BCD9DC9004C5B45 /* JITInlines.h in Headers */,
+				A3CA481A1BCD9DC9004C5B45 /* JITOperations.h in Headers */,
+				A3CA481B1BCD9DC9004C5B45 /* JSSetIterator.h in Headers */,
+				A3CA481C1BCD9DC9004C5B45 /* JITOperationWrappers.h in Headers */,
+				A3CA481D1BCD9DC9004C5B45 /* JITStubRoutine.h in Headers */,
+				A3CA481E1BCD9DC9004C5B45 /* JITStubRoutineSet.h in Headers */,
+				A3CA481F1BCD9DC9004C5B45 /* JITStubs.h in Headers */,
+				A3CA48201BCD9DC9004C5B45 /* JITStubsARM.h in Headers */,
+				A3CA48211BCD9DC9004C5B45 /* JITStubsARMv7.h in Headers */,
+				A3CA48221BCD9DC9004C5B45 /* JITStubsX86.h in Headers */,
+				A3CA48231BCD9DC9004C5B45 /* JITStubsX86_64.h in Headers */,
+				A3CA48241BCD9DC9004C5B45 /* JITStubsX86Common.h in Headers */,
+				A3CA48251BCD9DC9004C5B45 /* JITThunks.h in Headers */,
+				A3CA48261BCD9DC9004C5B45 /* JITToDFGDeferredCompilationCallback.h in Headers */,
+				A3CA48271BCD9DC9004C5B45 /* JITWriteBarrier.h in Headers */,
+				A3CA48281BCD9DC9004C5B45 /* JSActivation.h in Headers */,
+				A3CA48291BCD9DC9004C5B45 /* JSAPIValueWrapper.h in Headers */,
+				A3CA482A1BCD9DC9004C5B45 /* JSAPIWrapperObject.h in Headers */,
+				A3CA482B1BCD9DC9004C5B45 /* JSArgumentsIterator.h in Headers */,
+				A3CA482C1BCD9DC9004C5B45 /* JSArray.h in Headers */,
+				A3CA482D1BCD9DC9004C5B45 /* JSArrayBuffer.h in Headers */,
+				A3CA482E1BCD9DC9004C5B45 /* JSArrayBufferConstructor.h in Headers */,
+				A3CA482F1BCD9DC9004C5B45 /* JSArrayBufferPrototype.h in Headers */,
+				A3CA48301BCD9DC9004C5B45 /* JSArrayBufferView.h in Headers */,
+				A3CA48311BCD9DC9004C5B45 /* JSArrayBufferViewInlines.h in Headers */,
+				A3CA48321BCD9DC9004C5B45 /* JSArrayIterator.h in Headers */,
+				A3CA48331BCD9DC9004C5B45 /* JSBase.h in Headers */,
+				A3CA48341BCD9DC9004C5B45 /* RecursiveAllocationScope.h in Headers */,
+				A3CA48351BCD9DC9004C5B45 /* JSBasePrivate.h in Headers */,
+				A3CA48361BCD9DC9004C5B45 /* JSBoundFunction.h in Headers */,
+				A3CA48371BCD9DC9004C5B45 /* JSCallbackConstructor.h in Headers */,
+				A3CA48381BCD9DC9004C5B45 /* JSCallbackFunction.h in Headers */,
+				A3CA48391BCD9DC9004C5B45 /* JSCallbackObject.h in Headers */,
+				A3CA483A1BCD9DC9004C5B45 /* JSCallbackObjectFunctions.h in Headers */,
+				A3CA483B1BCD9DC9004C5B45 /* JSCell.h in Headers */,
+				A3CA483C1BCD9DC9004C5B45 /* JSCellInlines.h in Headers */,
+				A3CA483D1BCD9DC9004C5B45 /* JSCJSValue.h in Headers */,
+				A3CA483E1BCD9DC9004C5B45 /* JSCJSValueInlines.h in Headers */,
+				A3CA483F1BCD9DC9004C5B45 /* JSClassRef.h in Headers */,
+				A3CA48401BCD9DC9004C5B45 /* JSContext.h in Headers */,
+				A3CA48411BCD9DC9004C5B45 /* JSContextInternal.h in Headers */,
+				A3CA48421BCD9DC9004C5B45 /* JSContextRef.h in Headers */,
+				A3CA48431BCD9DC9004C5B45 /* JSContextRefPrivate.h in Headers */,
+				A3CA48441BCD9DC9004C5B45 /* JSCTestRunnerUtils.h in Headers */,
+				A3CA48451BCD9DC9004C5B45 /* JSDataView.h in Headers */,
+				A3CA48461BCD9DC9004C5B45 /* JSDataViewPrototype.h in Headers */,
+				A3CA48471BCD9DC9004C5B45 /* JSDateMath.h in Headers */,
+				A3CA48481BCD9DC9004C5B45 /* JSDestructibleObject.h in Headers */,
+				A3CA48491BCD9DC9004C5B45 /* JSExport.h in Headers */,
+				A3CA484A1BCD9DC9004C5B45 /* JSExportMacros.h in Headers */,
+				A3CA484B1BCD9DC9004C5B45 /* JSFloat32Array.h in Headers */,
+				A3CA484C1BCD9DC9004C5B45 /* JSFloat64Array.h in Headers */,
+				A3CA484D1BCD9DC9004C5B45 /* JSFunction.h in Headers */,
+				A3CA484E1BCD9DC9004C5B45 /* JSFunctionInlines.h in Headers */,
+				A3CA484F1BCD9DC9004C5B45 /* JSGenericTypedArrayView.h in Headers */,
+				A3CA48501BCD9DC9004C5B45 /* JSGenericTypedArrayViewConstructor.h in Headers */,
+				A3CA48511BCD9DC9004C5B45 /* JSGenericTypedArrayViewConstructorInlines.h in Headers */,
+				A3CA48521BCD9DC9004C5B45 /* JSGenericTypedArrayViewInlines.h in Headers */,
+				A3CA48531BCD9DC9004C5B45 /* JSGenericTypedArrayViewPrototype.h in Headers */,
+				A3CA48541BCD9DC9004C5B45 /* JSGenericTypedArrayViewPrototypeInlines.h in Headers */,
+				A3CA48551BCD9DC9004C5B45 /* JSGlobalObject.h in Headers */,
+				A3CA48561BCD9DC9004C5B45 /* JSGlobalObjectFunctions.h in Headers */,
+				A3CA48571BCD9DC9004C5B45 /* JSInt16Array.h in Headers */,
+				A3CA48581BCD9DC9004C5B45 /* JSInt32Array.h in Headers */,
+				A3CA48591BCD9DC9004C5B45 /* JSInt8Array.h in Headers */,
+				A3CA485A1BCD9DC9004C5B45 /* JSInterfaceJIT.h in Headers */,
+				A3CA485B1BCD9DC9004C5B45 /* JSLock.h in Headers */,
+				A3CA485C1BCD9DC9004C5B45 /* JSManagedValue.h in Headers */,
+				A3CA485D1BCD9DC9004C5B45 /* JSMap.h in Headers */,
+				A3CA485E1BCD9DC9004C5B45 /* JSNameScope.h in Headers */,
+				A3CA485F1BCD9DC9004C5B45 /* JSObject.h in Headers */,
+				A3CA48601BCD9DC9004C5B45 /* JSObjectRef.h in Headers */,
+				A3CA48611BCD9DC9004C5B45 /* JSObjectRefPrivate.h in Headers */,
+				A3CA48621BCD9DC9004C5B45 /* JSONObject.h in Headers */,
+				A3CA48631BCD9DC9004C5B45 /* JSONObject.lut.h in Headers */,
+				A3CA48641BCD9DC9004C5B45 /* JSProfilerPrivate.h in Headers */,
+				A3CA48651BCD9DC9004C5B45 /* JSPromise.h in Headers */,
+				A3CA48661BCD9DC9004C5B45 /* JSPromiseConstructor.h in Headers */,
+				A3CA48671BCD9DC9004C5B45 /* JSPromisePrototype.h in Headers */,
+				A3CA48681BCD9DC9004C5B45 /* JSMapIterator.h in Headers */,
+				A3CA48691BCD9DC9004C5B45 /* JSProxy.h in Headers */,
+				A3CA486A1BCD9DC9004C5B45 /* JSRetainPtr.h in Headers */,
+				A3CA486B1BCD9DC9004C5B45 /* JSScope.h in Headers */,
+				A3CA486C1BCD9DC9004C5B45 /* JSScriptRefPrivate.h in Headers */,
+				A3CA486D1BCD9DC9004C5B45 /* JSSegmentedVariableObject.h in Headers */,
+				A3CA486E1BCD9DC9004C5B45 /* JSSet.h in Headers */,
+				A3CA486F1BCD9DC9004C5B45 /* JSStack.h in Headers */,
+				A3CA48701BCD9DC9004C5B45 /* JSStackInlines.h in Headers */,
+				A3CA48711BCD9DC9004C5B45 /* JSString.h in Headers */,
+				A3CA48721BCD9DC9004C5B45 /* JSStringBuilder.h in Headers */,
+				A3CA48731BCD9DC9004C5B45 /* JSStringJoiner.h in Headers */,
+				A3CA48741BCD9DC9004C5B45 /* JSStringRef.h in Headers */,
+				A3CA48751BCD9DC9004C5B45 /* JSStringRefCF.h in Headers */,
+				A3CA48761BCD9DC9004C5B45 /* JSStringRefPrivate.h in Headers */,
+				A3CA48771BCD9DC9004C5B45 /* JSSymbolTableObject.h in Headers */,
+				A3CA48781BCD9DC9004C5B45 /* JSType.h in Headers */,
+				A3CA48791BCD9DC9004C5B45 /* JSTypedArrayConstructors.h in Headers */,
+				A3CA487A1BCD9DC9004C5B45 /* JSTypedArrayPrototypes.h in Headers */,
+				A3CA487B1BCD9DC9004C5B45 /* JSTypedArrays.h in Headers */,
+				A3CA487C1BCD9DC9004C5B45 /* JSTypeInfo.h in Headers */,
+				A3CA487D1BCD9DC9004C5B45 /* JSUint16Array.h in Headers */,
+				A3CA487E1BCD9DC9004C5B45 /* JSUint32Array.h in Headers */,
+				A3CA487F1BCD9DC9004C5B45 /* JSUint8Array.h in Headers */,
+				A3CA48801BCD9DC9004C5B45 /* JSUint8ClampedArray.h in Headers */,
+				A3CA48811BCD9DC9004C5B45 /* JSValue.h in Headers */,
+				A3CA48821BCD9DC9004C5B45 /* JSValueInternal.h in Headers */,
+				A3CA48831BCD9DC9004C5B45 /* JSValueRef.h in Headers */,
+				A3CA48841BCD9DC9004C5B45 /* JSVariableObject.h in Headers */,
+				A3CA48851BCD9DC9004C5B45 /* JSVirtualMachine.h in Headers */,
+				A3CA48861BCD9DC9004C5B45 /* JSVirtualMachineInternal.h in Headers */,
+				A3CA48871BCD9DC9004C5B45 /* JSWeakMap.h in Headers */,
+				A3CA48881BCD9DC9004C5B45 /* JSWeakObjectMapRefInternal.h in Headers */,
+				A3CA48891BCD9DC9004C5B45 /* JSWeakObjectMapRefPrivate.h in Headers */,
+				A3CA488A1BCD9DC9004C5B45 /* JSWithScope.h in Headers */,
+				A3CA488B1BCD9DC9004C5B45 /* JSWrapperMap.h in Headers */,
+				A3CA488C1BCD9DC9004C5B45 /* JSWrapperObject.h in Headers */,
+				A3CA488D1BCD9DC9004C5B45 /* JumpTable.h in Headers */,
+				A3CA488E1BCD9DC9004C5B45 /* MapIteratorPrototype.h in Headers */,
+				A3CA488F1BCD9DC9004C5B45 /* KeywordLookup.h in Headers */,
+				A3CA48901BCD9DC9004C5B45 /* Label.h in Headers */,
+				A3CA48911BCD9DC9004C5B45 /* LabelScope.h in Headers */,
+				A3CA48921BCD9DC9004C5B45 /* LazyOperandValueProfile.h in Headers */,
+				A3CA48931BCD9DC9004C5B45 /* LegacyProfiler.h in Headers */,
+				A3CA48941BCD9DC9004C5B45 /* Lexer.h in Headers */,
+				A3CA48951BCD9DC9004C5B45 /* Lexer.lut.h in Headers */,
+				A3CA48961BCD9DC9004C5B45 /* LineInfo.h in Headers */,
+				A3CA48971BCD9DC9004C5B45 /* LinkBuffer.h in Headers */,
+				A3CA48981BCD9DC9004C5B45 /* ListableHandler.h in Headers */,
+				A3CA48991BCD9DC9004C5B45 /* LiteralParser.h in Headers */,
+				A3CA489A1BCD9DC9004C5B45 /* LLIntCallLinkInfo.h in Headers */,
+				A3CA489B1BCD9DC9004C5B45 /* LLIntCLoop.h in Headers */,
+				A3CA489C1BCD9DC9004C5B45 /* LLIntCommon.h in Headers */,
+				A3CA489D1BCD9DC9004C5B45 /* LLIntData.h in Headers */,
+				A3CA489E1BCD9DC9004C5B45 /* LLIntEntrypoint.h in Headers */,
+				A3CA489F1BCD9DC9004C5B45 /* LLIntExceptions.h in Headers */,
+				A3CA48A01BCD9DC9004C5B45 /* LLIntOfflineAsmConfig.h in Headers */,
+				A3CA48A11BCD9DC9004C5B45 /* LLIntOpcode.h in Headers */,
+				A3CA48A21BCD9DC9004C5B45 /* JSPromiseDeferred.h in Headers */,
+				A3CA48A31BCD9DC9004C5B45 /* LLIntSlowPaths.h in Headers */,
+				A3CA48A41BCD9DC9004C5B45 /* LLIntThunks.h in Headers */,
+				A3CA48A51BCD9DC9004C5B45 /* LLVMAPI.h in Headers */,
+				A3CA48A61BCD9DC9004C5B45 /* LLVMAPIFunctions.h in Headers */,
+				A3CA48A71BCD9DC9004C5B45 /* LLVMDisassembler.h in Headers */,
+				A3CA48A81BCD9DC9004C5B45 /* LLVMHeaders.h in Headers */,
+				A3CA48A91BCD9DC9004C5B45 /* Local.h in Headers */,
+				A3CA48AA1BCD9DC9004C5B45 /* LocalScope.h in Headers */,
+				A3CA48AB1BCD9DC9004C5B45 /* Lookup.h in Headers */,
+				A3CA48AC1BCD9DC9004C5B45 /* LowLevelInterpreter.h in Headers */,
+				A3CA48AD1BCD9DC9004C5B45 /* MachineStackMarker.h in Headers */,
+				A3CA48AE1BCD9DC9004C5B45 /* MacroAssembler.h in Headers */,
+				A3CA48AF1BCD9DC9004C5B45 /* MacroAssemblerARM.h in Headers */,
+				A3CA48B01BCD9DC9004C5B45 /* MacroAssemblerARMv7.h in Headers */,
+				A3CA48B11BCD9DC9004C5B45 /* MacroAssemblerCodeRef.h in Headers */,
+				A3CA48B21BCD9DC9004C5B45 /* MacroAssemblerMIPS.h in Headers */,
+				A3CA48B31BCD9DC9004C5B45 /* MacroAssemblerSH4.h in Headers */,
+				A3CA48B41BCD9DC9004C5B45 /* MacroAssemblerX86.h in Headers */,
+				A3CA48B51BCD9DC9004C5B45 /* MacroAssemblerX86_64.h in Headers */,
+				A3CA48B61BCD9DC9004C5B45 /* MacroAssemblerX86Common.h in Headers */,
+				A3CA48B71BCD9DC9004C5B45 /* MapConstructor.h in Headers */,
+				A3CA48B81BCD9DC9004C5B45 /* MapData.h in Headers */,
+				A3CA48B91BCD9DC9004C5B45 /* MapPrototype.h in Headers */,
+				A3CA48BA1BCD9DC9004C5B45 /* MarkedAllocator.h in Headers */,
+				A3CA48BB1BCD9DC9004C5B45 /* MarkedBlock.h in Headers */,
+				A3CA48BC1BCD9DC9004C5B45 /* MarkedBlockSet.h in Headers */,
+				A3CA48BD1BCD9DC9004C5B45 /* MarkedSpace.h in Headers */,
+				A3CA48BE1BCD9DC9004C5B45 /* MarkStack.h in Headers */,
+				A3CA48BF1BCD9DC9004C5B45 /* MarkStackInlines.h in Headers */,
+				A3CA48C01BCD9DC9004C5B45 /* InspectorFrontendChannel.h in Headers */,
+				A3CA48C11BCD9DC9004C5B45 /* MatchResult.h in Headers */,
+				A3CA48C21BCD9DC9004C5B45 /* MathObject.h in Headers */,
+				A3CA48C31BCD9DC9004C5B45 /* MemoryStatistics.h in Headers */,
+				A3CA48C41BCD9DC9004C5B45 /* MethodOfGettingAValueProfile.h in Headers */,
+				A3CA48C51BCD9DC9004C5B45 /* MIPSAssembler.h in Headers */,
+				A3CA48C61BCD9DC9004C5B45 /* NameConstructor.h in Headers */,
+				A3CA48C71BCD9DC9004C5B45 /* SetIteratorPrototype.h in Headers */,
+				A3CA48C81BCD9DC9004C5B45 /* NameInstance.h in Headers */,
+				A3CA48C91BCD9DC9004C5B45 /* NamePrototype.h in Headers */,
+				A3CA48CA1BCD9DC9004C5B45 /* NativeErrorConstructor.h in Headers */,
+				A3CA48CB1BCD9DC9004C5B45 /* NativeErrorPrototype.h in Headers */,
+				A3CA48CC1BCD9DC9004C5B45 /* NodeConstructors.h in Headers */,
+				A3CA48CD1BCD9DC9004C5B45 /* NodeInfo.h in Headers */,
+				A3CA48CE1BCD9DC9004C5B45 /* Nodes.h in Headers */,
+				A3CA48CF1BCD9DC9004C5B45 /* NumberConstructor.h in Headers */,
+				A3CA48D01BCD9DC9004C5B45 /* NumberConstructor.lut.h in Headers */,
+				A3CA48D11BCD9DC9004C5B45 /* NumberObject.h in Headers */,
+				A3CA48D21BCD9DC9004C5B45 /* NumberPrototype.h in Headers */,
+				A3CA48D31BCD9DC9004C5B45 /* NumericStrings.h in Headers */,
+				A3CA48D41BCD9DC9004C5B45 /* ObjCCallbackFunction.h in Headers */,
+				A3CA48D51BCD9DC9004C5B45 /* ObjcRuntimeExtras.h in Headers */,
+				A3CA48D61BCD9DC9004C5B45 /* ObjectAllocationProfile.h in Headers */,
+				A3CA48D71BCD9DC9004C5B45 /* ObjectConstructor.h in Headers */,
+				A3CA48D81BCD9DC9004C5B45 /* ObjectPrototype.h in Headers */,
+				A3CA48D91BCD9DC9004C5B45 /* OpaqueJSString.h in Headers */,
+				A3CA48DA1BCD9DC9004C5B45 /* Opcode.h in Headers */,
+				A3CA48DB1BCD9DC9004C5B45 /* Operands.h in Headers */,
+				A3CA48DC1BCD9DC9004C5B45 /* ARM64Assembler.h in Headers */,
+				A3CA48DD1BCD9DC9004C5B45 /* OperandsInlines.h in Headers */,
+				A3CA48DE1BCD9DC9004C5B45 /* Operations.h in Headers */,
+				A3CA48DF1BCD9DC9004C5B45 /* Options.h in Headers */,
+				A3CA48E01BCD9DC9004C5B45 /* Parser.h in Headers */,
+				A3CA48E11BCD9DC9004C5B45 /* ParserArena.h in Headers */,
+				A3CA48E21BCD9DC9004C5B45 /* ParserError.h in Headers */,
+				A3CA48E31BCD9DC9004C5B45 /* ParserModes.h in Headers */,
+				A3CA48E41BCD9DC9004C5B45 /* ParserTokens.h in Headers */,
+				A3CA48E51BCD9DC9004C5B45 /* PolymorphicAccessStructureList.h in Headers */,
+				A3CA48E61BCD9DC9004C5B45 /* PolymorphicPutByIdList.h in Headers */,
+				A3CA48E71BCD9DC9004C5B45 /* PreciseJumpTargets.h in Headers */,
+				A3CA48E81BCD9DC9004C5B45 /* PrivateName.h in Headers */,
+				A3CA48E91BCD9DC9004C5B45 /* Profile.h in Headers */,
+				A3CA48EA1BCD9DC9004C5B45 /* ProfiledCodeBlockJettisoningWatchpoint.h in Headers */,
+				A3CA48EB1BCD9DC9004C5B45 /* ProfileGenerator.h in Headers */,
+				A3CA48EC1BCD9DC9004C5B45 /* ProfileNode.h in Headers */,
+				A3CA48ED1BCD9DC9004C5B45 /* ProfilerBytecode.h in Headers */,
+				A3CA48EE1BCD9DC9004C5B45 /* BytecodeLivenessAnalysisInlines.h in Headers */,
+				A3CA48EF1BCD9DC9004C5B45 /* ProfilerBytecodes.h in Headers */,
+				A3CA48F01BCD9DC9004C5B45 /* ProfilerBytecodeSequence.h in Headers */,
+				A3CA48F11BCD9DC9004C5B45 /* ProfilerCompilation.h in Headers */,
+				A3CA48F21BCD9DC9004C5B45 /* ProfilerCompilationKind.h in Headers */,
+				A3CA48F31BCD9DC9004C5B45 /* ProfilerCompiledBytecode.h in Headers */,
+				A3CA48F41BCD9DC9004C5B45 /* ProfilerDatabase.h in Headers */,
+				A3CA48F51BCD9DC9004C5B45 /* ProfilerExecutionCounter.h in Headers */,
+				A3CA48F61BCD9DC9004C5B45 /* ProfilerOrigin.h in Headers */,
+				A3CA48F71BCD9DC9004C5B45 /* ProfilerOriginStack.h in Headers */,
+				A3CA48F81BCD9DC9004C5B45 /* ProfilerOSRExit.h in Headers */,
+				A3CA48F91BCD9DC9004C5B45 /* ProfilerOSRExitSite.h in Headers */,
+				A3CA48FA1BCD9DC9004C5B45 /* ProfilerProfiledBytecodes.h in Headers */,
+				A3CA48FB1BCD9DC9004C5B45 /* PropertyDescriptor.h in Headers */,
+				A3CA48FC1BCD9DC9004C5B45 /* PropertyMapHashTable.h in Headers */,
+				A3CA48FD1BCD9DC9004C5B45 /* PropertyName.h in Headers */,
+				A3CA48FE1BCD9DC9004C5B45 /* PropertyNameArray.h in Headers */,
+				A3CA48FF1BCD9DC9004C5B45 /* PropertyOffset.h in Headers */,
+				A3CA49001BCD9DC9004C5B45 /* PropertySlot.h in Headers */,
+				A3CA49011BCD9DC9004C5B45 /* PropertyStorage.h in Headers */,
+				A3CA49021BCD9DC9004C5B45 /* Protect.h in Headers */,
+				A3CA49031BCD9DC9004C5B45 /* PrototypeMap.h in Headers */,
+				A3CA49041BCD9DC9004C5B45 /* PutByIdStatus.h in Headers */,
+				A3CA49051BCD9DC9004C5B45 /* PutDirectIndexMode.h in Headers */,
+				A3CA49061BCD9DC9004C5B45 /* Microtask.h in Headers */,
+				A3CA49071BCD9DC9004C5B45 /* PutKind.h in Headers */,
+				A3CA49081BCD9DC9004C5B45 /* PutPropertySlot.h in Headers */,
+				A3CA49091BCD9DC9004C5B45 /* InspectorBackendDispatcher.h in Headers */,
+				A3CA490A1BCD9DC9004C5B45 /* ReduceWhitespace.h in Headers */,
+				A3CA490B1BCD9DC9004C5B45 /* RegExp.h in Headers */,
+				A3CA490C1BCD9DC9004C5B45 /* RegExpCache.h in Headers */,
+				A3CA490D1BCD9DC9004C5B45 /* RegExpConstructor.h in Headers */,
+				A3CA490E1BCD9DC9004C5B45 /* JSPromiseReaction.h in Headers */,
+				A3CA490F1BCD9DC9004C5B45 /* RegExpConstructor.lut.h in Headers */,
+				A3CA49101BCD9DC9004C5B45 /* RegExpKey.h in Headers */,
+				A3CA49111BCD9DC9004C5B45 /* StackAlignment.h in Headers */,
+				A3CA49121BCD9DC9004C5B45 /* RegExpObject.h in Headers */,
+				A3CA49131BCD9DC9004C5B45 /* RegExpObject.lut.h in Headers */,
+				A3CA49141BCD9DC9004C5B45 /* RegExpPrototype.h in Headers */,
+				A3CA49151BCD9DC9004C5B45 /* Region.h in Headers */,
+				A3CA49161BCD9DC9004C5B45 /* Register.h in Headers */,
+				A3CA49171BCD9DC9004C5B45 /* RegisterID.h in Headers */,
+				A3CA49181BCD9DC9004C5B45 /* RegisterSet.h in Headers */,
+				A3CA49191BCD9DC9004C5B45 /* Reject.h in Headers */,
+				A3CA491A1BCD9DC9004C5B45 /* Repatch.h in Headers */,
+				A3CA491B1BCD9DC9004C5B45 /* RepatchBuffer.h in Headers */,
+				A3CA491C1BCD9DC9004C5B45 /* ResultType.h in Headers */,
+				A3CA491D1BCD9DC9004C5B45 /* SamplingCounter.h in Headers */,
+				A3CA491E1BCD9DC9004C5B45 /* SamplingTool.h in Headers */,
+				A3CA491F1BCD9DC9004C5B45 /* ScratchRegisterAllocator.h in Headers */,
+				A3CA49201BCD9DC9004C5B45 /* DelayedReleaseScope.h in Headers */,
+				A3CA49211BCD9DC9004C5B45 /* SetConstructor.h in Headers */,
+				A3CA49221BCD9DC9004C5B45 /* SetPrototype.h in Headers */,
+				A3CA49231BCD9DC9004C5B45 /* SH4Assembler.h in Headers */,
+				A3CA49241BCD9DC9004C5B45 /* SimpleTypedArrayController.h in Headers */,
+				A3CA49251BCD9DC9004C5B45 /* JSPromiseFunctions.h in Headers */,
+				A3CA49261BCD9DC9004C5B45 /* SetIteratorConstructor.h in Headers */,
+				A3CA49271BCD9DC9004C5B45 /* SlotVisitor.h in Headers */,
+				A3CA49281BCD9DC9004C5B45 /* SlotVisitorInlines.h in Headers */,
+				A3CA49291BCD9DC9004C5B45 /* SlowPathCall.h in Headers */,
+				A3CA492A1BCD9DC9004C5B45 /* SmallStrings.h in Headers */,
+				A3CA492B1BCD9DC9004C5B45 /* SourceCode.h in Headers */,
+				A3CA492C1BCD9DC9004C5B45 /* SourceProvider.h in Headers */,
+				A3CA492D1BCD9DC9004C5B45 /* SourceProviderCache.h in Headers */,
+				A3CA492E1BCD9DC9004C5B45 /* SourceProviderCacheItem.h in Headers */,
+				A3CA492F1BCD9DC9004C5B45 /* SparseArrayValueMap.h in Headers */,
+				A3CA49301BCD9DC9004C5B45 /* SpecializedThunkJIT.h in Headers */,
+				A3CA49311BCD9DC9004C5B45 /* SpecialPointer.h in Headers */,
+				A3CA49321BCD9DC9004C5B45 /* SpeculatedType.h in Headers */,
+				A3CA49331BCD9DC9004C5B45 /* StackVisitor.h in Headers */,
+				A3CA49341BCD9DC9004C5B45 /* StaticPropertyAnalysis.h in Headers */,
+				A3CA49351BCD9DC9004C5B45 /* ScriptObject.h in Headers */,
+				A3CA49361BCD9DC9004C5B45 /* StaticPropertyAnalyzer.h in Headers */,
+				A3CA49371BCD9DC9004C5B45 /* StrictEvalActivation.h in Headers */,
+				A3CA49381BCD9DC9004C5B45 /* StringConstructor.h in Headers */,
+				A3CA49391BCD9DC9004C5B45 /* StringObject.h in Headers */,
+				A3CA493A1BCD9DC9004C5B45 /* StringPrototype.h in Headers */,
+				A3CA493B1BCD9DC9004C5B45 /* Strong.h in Headers */,
+				A3CA493C1BCD9DC9004C5B45 /* StrongInlines.h in Headers */,
+				A3CA493D1BCD9DC9004C5B45 /* Structure.h in Headers */,
+				A3CA493E1BCD9DC9004C5B45 /* StructureChain.h in Headers */,
+				A3CA493F1BCD9DC9004C5B45 /* StructureInlines.h in Headers */,
+				A3CA49401BCD9DC9004C5B45 /* StructureRareData.h in Headers */,
+				A3CA49411BCD9DC9004C5B45 /* StructureRareDataInlines.h in Headers */,
+				A3CA49421BCD9DC9004C5B45 /* StructureSet.h in Headers */,
+				A3CA49431BCD9DC9004C5B45 /* StructureStubClearingWatchpoint.h in Headers */,
+				A3CA49441BCD9DC9004C5B45 /* StructureStubInfo.h in Headers */,
+				A3CA49451BCD9DC9004C5B45 /* StructureTransitionTable.h in Headers */,
+				A3CA49461BCD9DC9004C5B45 /* SuperRegion.h in Headers */,
+				A3CA49471BCD9DC9004C5B45 /* SymbolTable.h in Headers */,
+				A3CA49481BCD9DC9004C5B45 /* SyntaxChecker.h in Headers */,
+				A3CA49491BCD9DC9004C5B45 /* TestRunnerUtils.h in Headers */,
+				A3CA494A1BCD9DC9004C5B45 /* ThunkGenerator.h in Headers */,
+				A3CA494B1BCD9DC9004C5B45 /* ThunkGenerators.h in Headers */,
+				A3CA494C1BCD9DC9004C5B45 /* TinyBloomFilter.h in Headers */,
+				A3CA494D1BCD9DC9004C5B45 /* ToNativeFromValue.h in Headers */,
+				A3CA494E1BCD9DC9004C5B45 /* Tracing.h in Headers */,
+				A3CA494F1BCD9DC9004C5B45 /* TypedArrayAdaptors.h in Headers */,
+				A3CA49501BCD9DC9004C5B45 /* TypedArrayController.h in Headers */,
+				A3CA49511BCD9DC9004C5B45 /* TypedArrayInlines.h in Headers */,
+				A3CA49521BCD9DC9004C5B45 /* TypedArrays.h in Headers */,
+				A3CA49531BCD9DC9004C5B45 /* TypedArrayType.h in Headers */,
+				A3CA49541BCD9DC9004C5B45 /* udis86.h in Headers */,
+				A3CA49551BCD9DC9004C5B45 /* udis86_decode.h in Headers */,
+				A3CA49561BCD9DC9004C5B45 /* udis86_extern.h in Headers */,
+				A3CA49571BCD9DC9004C5B45 /* udis86_input.h in Headers */,
+				A3CA49581BCD9DC9004C5B45 /* udis86_syn.h in Headers */,
+				A3CA49591BCD9DC9004C5B45 /* udis86_types.h in Headers */,
+				A3CA495A1BCD9DC9004C5B45 /* UDis86Disassembler.h in Headers */,
+				A3CA495B1BCD9DC9004C5B45 /* Uint16Array.h in Headers */,
+				A3CA495C1BCD9DC9004C5B45 /* Uint16WithFraction.h in Headers */,
+				A3CA495D1BCD9DC9004C5B45 /* Uint32Array.h in Headers */,
+				A3CA495E1BCD9DC9004C5B45 /* Uint8Array.h in Headers */,
+				A3CA495F1BCD9DC9004C5B45 /* Uint8ClampedArray.h in Headers */,
+				A3CA49601BCD9DC9004C5B45 /* UnconditionalFinalizer.h in Headers */,
+				A3CA49611BCD9DC9004C5B45 /* DFGAvailability.h in Headers */,
+				A3CA49621BCD9DC9004C5B45 /* UnlinkedCodeBlock.h in Headers */,
+				A3CA49631BCD9DC9004C5B45 /* UnusedPointer.h in Headers */,
+				A3CA49641BCD9DC9004C5B45 /* ValueProfile.h in Headers */,
+				A3CA49651BCD9DC9004C5B45 /* ValueRecovery.h in Headers */,
+				A3CA49661BCD9DC9004C5B45 /* VirtualRegister.h in Headers */,
+				A3CA49671BCD9DC9004C5B45 /* VM.h in Headers */,
+				A3CA49681BCD9DC9004C5B45 /* VMInspector.h in Headers */,
+				A3CA49691BCD9DC9004C5B45 /* InjectedScriptSource.h in Headers */,
+				A3CA496A1BCD9DC9004C5B45 /* Watchdog.h in Headers */,
+				A3CA496B1BCD9DC9004C5B45 /* Watchpoint.h in Headers */,
+				A3CA496C1BCD9DC9004C5B45 /* Weak.h in Headers */,
+				A3CA496D1BCD9DC9004C5B45 /* WeakBlock.h in Headers */,
+				A3CA496E1BCD9DC9004C5B45 /* WeakGCMap.h in Headers */,
+				A3CA496F1BCD9DC9004C5B45 /* RemoteInspector.h in Headers */,
+				A3CA49701BCD9DC9004C5B45 /* WeakHandleOwner.h in Headers */,
+				A3CA49711BCD9DC9004C5B45 /* WeakImpl.h in Headers */,
+				A3CA49721BCD9DC9004C5B45 /* WeakInlines.h in Headers */,
+				A3CA49731BCD9DC9004C5B45 /* WeakMapConstructor.h in Headers */,
+				A3CA49741BCD9DC9004C5B45 /* WeakMapData.h in Headers */,
+				A3CA49751BCD9DC9004C5B45 /* DFGStoreBarrierElisionPhase.h in Headers */,
+				A3CA49761BCD9DC9004C5B45 /* InspectorTypeBuilder.h in Headers */,
+				A3CA49771BCD9DC9004C5B45 /* WeakMapPrototype.h in Headers */,
+				A3CA49781BCD9DC9004C5B45 /* WeakRandom.h in Headers */,
+				A3CA49791BCD9DC9004C5B45 /* WeakReferenceHarvester.h in Headers */,
+				A3CA497A1BCD9DC9004C5B45 /* WeakSet.h in Headers */,
+				A3CA497B1BCD9DC9004C5B45 /* WeakSetInlines.h in Headers */,
+				A3CA497C1BCD9DC9004C5B45 /* WebKitAvailability.h in Headers */,
+				A3CA497D1BCD9DC9004C5B45 /* MapIteratorConstructor.h in Headers */,
+				A3CA497E1BCD9DC9004C5B45 /* WriteBarrier.h in Headers */,
+				A3CA497F1BCD9DC9004C5B45 /* WriteBarrierSupport.h in Headers */,
+				A3CA49801BCD9DC9004C5B45 /* X86Assembler.h in Headers */,
+				A3CA49811BCD9DC9004C5B45 /* Yarr.h in Headers */,
+				A3CA49821BCD9DC9004C5B45 /* DFGResurrectionForValidationPhase.h in Headers */,
+				A3CA49831BCD9DC9004C5B45 /* YarrInterpreter.h in Headers */,
+				A3CA49841BCD9DC9004C5B45 /* ScriptFunctionCall.h in Headers */,
+				A3CA49851BCD9DC9004C5B45 /* YarrJIT.h in Headers */,
+				A3CA49861BCD9DC9004C5B45 /* YarrParser.h in Headers */,
+				A3CA49871BCD9DC9004C5B45 /* YarrPattern.h in Headers */,
+				A3CA49881BCD9DC9004C5B45 /* YarrSyntaxChecker.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -7252,6 +9209,31 @@
 			productReference = 932F5BE10822A1C700736975 /* jsc */;
 			productType = "com.apple.product-type.tool";
 		};
+		A3CA46B11BCD9DC9004C5B45 /* JavaScriptCore tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A3CA4B731BCD9DC9004C5B45 /* Build configuration list for PBXNativeTarget "JavaScriptCore tvOS" */;
+			buildPhases = (
+				A3CA46B41BCD9DC9004C5B45 /* Update Info.plist with version information */,
+				A3CA46B51BCD9DC9004C5B45 /* Headers */,
+				A3CA49891BCD9DC9004C5B45 /* Postprocess Headers */,
+				A3CA498A1BCD9DC9004C5B45 /* Sources */,
+				A3CA4B6B1BCD9DC9004C5B45 /* Frameworks */,
+				A3CA4B6F1BCD9DC9004C5B45 /* Copy LLVM Library Into Framework */,
+				A3CA4B701BCD9DC9004C5B45 /* Check For Weak VTables and Externals */,
+				A3CA4B711BCD9DC9004C5B45 /* Check For Inappropriate Objective-C Class Names */,
+				A3CA4B721BCD9DC9004C5B45 /* Check For Inappropriate Macros in External Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A3CA46B21BCD9DC9004C5B45 /* PBXTargetDependency */,
+			);
+			name = "JavaScriptCore tvOS";
+			productInstallPath = "${SYSTEM_LIBRARY_DIR}/Frameworks/WebKit.framework/Versions/A/Frameworks";
+			productName = JavaScriptCore;
+			productReference = A3CA4B781BCD9DC9004C5B45 /* libJavaScriptCore-tvOS.a */;
+			productType = "com.apple.product-type.library.static";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -7291,6 +9273,7 @@
 				10D58E011889C1A000C05A0D /* JSCLLIntOffsetsExtractor iOS */,
 				10D58E0D1889C3DF00C05A0D /* JavaScriptCore iOS */,
 				10D592F61889C55E00C05A0D /* Derived Sources iOS */,
+				A3CA46B11BCD9DC9004C5B45 /* JavaScriptCore tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -7578,6 +9561,101 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "mkdir -p \"${BUILT_PRODUCTS_DIR}/DerivedSources/JavaScriptCore\"\ncd \"${BUILT_PRODUCTS_DIR}/DerivedSources/JavaScriptCore\"\n\n/bin/ln -sfh \"${SRCROOT}\" JavaScriptCore\nexport JavaScriptCore=\"JavaScriptCore\"\nexport BUILT_PRODUCTS_DIR=\"../..\"\n\nmake --no-builtin-rules -f \"JavaScriptCore/DerivedSources.make\" -j `/usr/sbin/sysctl -n hw.ncpu` || exit 1\n\nif [[ \"${ACTION}\" == \"installhdrs\" ]]; then\n    exit 0\nfi\n\n/usr/bin/env ruby JavaScriptCore/offlineasm/asm.rb JavaScriptCore/llint/LowLevelInterpreter.asm ${BUILT_PRODUCTS_DIR}/JSCLLIntOffsetsExtractor LLIntAssembly.h || exit 1\n";
+		};
+		A3CA46B41BCD9DC9004C5B45 /* Update Info.plist with version information */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(SRCROOT)/Configurations/Version.xcconfig",
+			);
+			name = "Update Info.plist with version information";
+			outputPaths = (
+				"$(SRCROOT)/Info.plist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "# Touch Info.plist to let Xcode know it needs to copy it into the built product\nif [[ \"${CONFIGURATION}\" != \"Production\" ]]; then\n    touch \"$SRCROOT/Info.plist\";\nfi;\n";
+		};
+		A3CA49891BCD9DC9004C5B45 /* Postprocess Headers */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)/JSBase.h",
+				"$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)/JSContext.h",
+				"$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)/JSManagedValue.h",
+				"$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)/JSValue.h",
+				"$(TARGET_BUILD_DIR)/$(PUBLIC_HEADERS_FOLDER_PATH)/JSVirtualMachine.h",
+			);
+			name = "Postprocess Headers";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "cd \"${TARGET_BUILD_DIR}/${PUBLIC_HEADERS_FOLDER_PATH}\"\n\nif [[ ${TARGET_MAC_OS_X_VERSION_MAJOR} == \"1080\" ]]; then\n    UNIFDEF_OPTION=\"-DJSC_OBJC_API_AVAILABLE_MAC_OS_X_1080\";\nelse\n    UNIFDEF_OPTION=\"-UJSC_OBJC_API_AVAILABLE_MAC_OS_X_1080\";\nfi\n\nfor HEADER in JSBase.h JSContext.h JSManagedValue.h JSValue.h JSVirtualMachine.h; do\n    unifdef -B ${UNIFDEF_OPTION} -o ${HEADER}.unifdef ${HEADER}\n    case $? in\n    0)\n        rm ${HEADER}.unifdef\n        ;;\n    1)\n        mv ${HEADER}{.unifdef,}\n        ;;\n    *)\n        exit 1\n    esac\ndone\n";
+		};
+		A3CA4B6F1BCD9DC9004C5B45 /* Copy LLVM Library Into Framework */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(BUILT_PRODUCTS_DIR)/libllvmForJSC.dylib",
+			);
+			name = "Copy LLVM Library Into Framework";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ $ENABLE_FTL_JIT != \"ENABLE_FTL_JIT\" ]]\nthen\n    exit 0\nfi\n\n# Copy the llvmForJSC library into the framework.\nditto \"${BUILT_PRODUCTS_DIR}/libllvmForJSC.dylib\" \"${BUILT_PRODUCTS_DIR}/${CONTENTS_FOLDER_PATH}/Libraries/libllvmForJSC.dylib\"\nif [ ! -e \"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Libraries\" ]\nthen\n    ln -fs \"Versions/Current/Libraries\" \"${BUILT_PRODUCTS_DIR}/${WRAPPER_NAME}/Libraries\"\nfi";
+		};
+		A3CA4B701BCD9DC9004C5B45 /* Check For Weak VTables and Externals */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Check For Weak VTables and Externals";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ -f ../../Tools/Scripts/check-for-weak-vtables-and-externals ]; then\n    ../../Tools/Scripts/check-for-weak-vtables-and-externals || exit $?\nfi";
+		};
+		A3CA4B711BCD9DC9004C5B45 /* Check For Inappropriate Objective-C Class Names */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Check For Inappropriate Objective-C Class Names";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${ACTION}\" = \"installhdrs\" ]; then\n    exit 0;\nfi\n\nif [ -f ../../Tools/Scripts/check-for-inappropriate-objc-class-names ]; then\n    ../../Tools/Scripts/check-for-inappropriate-objc-class-names JS || exit $?\nfi";
+		};
+		A3CA4B721BCD9DC9004C5B45 /* Check For Inappropriate Macros in External Headers */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+				"$(TARGET_BUILD_DIR)/$(EXECUTABLE_PATH)",
+			);
+			name = "Check For Inappropriate Macros in External Headers";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [ \"${ACTION}\" = \"installhdrs\" ]; then\n    exit 0;\nfi\n\nif [ -f ../../Tools/Scripts/check-for-inappropriate-macros-in-external-headers ]; then\n    ../../Tools/Scripts/check-for-inappropriate-macros-in-external-headers Headers PrivateHeaders/JSBasePrivate.h || exit $?\nfi";
 		};
 		A55DEAA416703DF7003DB841 /* Check For Inappropriate Macros in External Headers */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -8635,6 +10713,493 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A3CA498A1BCD9DC9004C5B45 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A3CA498B1BCD9DC9004C5B45 /* ProtoCallFrame.cpp in Sources */,
+				A3CA498C1BCD9DC9004C5B45 /* A64DOpcode.cpp in Sources */,
+				A3CA498D1BCD9DC9004C5B45 /* AbstractPC.cpp in Sources */,
+				A3CA498E1BCD9DC9004C5B45 /* ArgList.cpp in Sources */,
+				A3CA498F1BCD9DC9004C5B45 /* Arguments.cpp in Sources */,
+				A3CA49901BCD9DC9004C5B45 /* ArgumentsIteratorConstructor.cpp in Sources */,
+				A3CA49911BCD9DC9004C5B45 /* ArgumentsIteratorPrototype.cpp in Sources */,
+				A3CA49921BCD9DC9004C5B45 /* ARM64Disassembler.cpp in Sources */,
+				A3CA49931BCD9DC9004C5B45 /* ARMAssembler.cpp in Sources */,
+				A3CA49941BCD9DC9004C5B45 /* ARMv7Assembler.cpp in Sources */,
+				A3CA49951BCD9DC9004C5B45 /* ARMv7Disassembler.cpp in Sources */,
+				A3CA49961BCD9DC9004C5B45 /* ARMv7DOpcode.cpp in Sources */,
+				A3CA49971BCD9DC9004C5B45 /* ArrayAllocationProfile.cpp in Sources */,
+				A3CA49981BCD9DC9004C5B45 /* ArrayBuffer.cpp in Sources */,
+				A3CA49991BCD9DC9004C5B45 /* ArrayBufferView.cpp in Sources */,
+				A3CA499A1BCD9DC9004C5B45 /* ArrayConstructor.cpp in Sources */,
+				A3CA499B1BCD9DC9004C5B45 /* ArrayIteratorConstructor.cpp in Sources */,
+				A3CA499C1BCD9DC9004C5B45 /* ArrayIteratorPrototype.cpp in Sources */,
+				A3CA499D1BCD9DC9004C5B45 /* JSSetIterator.cpp in Sources */,
+				A3CA499E1BCD9DC9004C5B45 /* ArrayProfile.cpp in Sources */,
+				A3CA499F1BCD9DC9004C5B45 /* ArrayPrototype.cpp in Sources */,
+				A3CA49A01BCD9DC9004C5B45 /* AssemblyHelpers.cpp in Sources */,
+				A3CA49A11BCD9DC9004C5B45 /* BlockAllocator.cpp in Sources */,
+				A3CA49A21BCD9DC9004C5B45 /* BooleanConstructor.cpp in Sources */,
+				A3CA49A31BCD9DC9004C5B45 /* BooleanObject.cpp in Sources */,
+				A3CA49A41BCD9DC9004C5B45 /* BooleanPrototype.cpp in Sources */,
+				A3CA49A51BCD9DC9004C5B45 /* BytecodeGenerator.cpp in Sources */,
+				A3CA49A61BCD9DC9004C5B45 /* CallData.cpp in Sources */,
+				A3CA49A71BCD9DC9004C5B45 /* CallFrame.cpp in Sources */,
+				A3CA49A81BCD9DC9004C5B45 /* CallLinkInfo.cpp in Sources */,
+				A3CA49A91BCD9DC9004C5B45 /* CallLinkStatus.cpp in Sources */,
+				A3CA49AA1BCD9DC9004C5B45 /* ClosureCallStubRoutine.cpp in Sources */,
+				A3CA49AB1BCD9DC9004C5B45 /* CodeBlock.cpp in Sources */,
+				A3CA49AC1BCD9DC9004C5B45 /* CodeBlockHash.cpp in Sources */,
+				A3CA49AD1BCD9DC9004C5B45 /* CodeBlockJettisoningWatchpoint.cpp in Sources */,
+				A3CA49AE1BCD9DC9004C5B45 /* CodeBlockSet.cpp in Sources */,
+				A3CA49AF1BCD9DC9004C5B45 /* CodeCache.cpp in Sources */,
+				A3CA49B01BCD9DC9004C5B45 /* CodeOrigin.cpp in Sources */,
+				A3CA49B11BCD9DC9004C5B45 /* CodeProfile.cpp in Sources */,
+				A3CA49B21BCD9DC9004C5B45 /* CodeProfiling.cpp in Sources */,
+				A3CA49B31BCD9DC9004C5B45 /* CodeSpecializationKind.cpp in Sources */,
+				A3CA49B41BCD9DC9004C5B45 /* CodeType.cpp in Sources */,
+				A3CA49B51BCD9DC9004C5B45 /* CommonIdentifiers.cpp in Sources */,
+				A3CA49B61BCD9DC9004C5B45 /* CommonSlowPaths.cpp in Sources */,
+				A3CA49B71BCD9DC9004C5B45 /* CommonSlowPathsExceptions.cpp in Sources */,
+				A3CA49B81BCD9DC9004C5B45 /* CompilationResult.cpp in Sources */,
+				A3CA49B91BCD9DC9004C5B45 /* Completion.cpp in Sources */,
+				A3CA49BA1BCD9DC9004C5B45 /* ConservativeRoots.cpp in Sources */,
+				A3CA49BB1BCD9DC9004C5B45 /* ConstructData.cpp in Sources */,
+				A3CA49BC1BCD9DC9004C5B45 /* CopiedSpace.cpp in Sources */,
+				A3CA49BD1BCD9DC9004C5B45 /* CopyVisitor.cpp in Sources */,
+				A3CA49BE1BCD9DC9004C5B45 /* DataView.cpp in Sources */,
+				A3CA49BF1BCD9DC9004C5B45 /* DateConstructor.cpp in Sources */,
+				A3CA49C01BCD9DC9004C5B45 /* DateConversion.cpp in Sources */,
+				A3CA49C11BCD9DC9004C5B45 /* DateInstance.cpp in Sources */,
+				A3CA49C21BCD9DC9004C5B45 /* DatePrototype.cpp in Sources */,
+				A3CA49C31BCD9DC9004C5B45 /* BytecodeLivenessAnalysis.cpp in Sources */,
+				A3CA49C41BCD9DC9004C5B45 /* Debugger.cpp in Sources */,
+				A3CA49C51BCD9DC9004C5B45 /* DebuggerActivation.cpp in Sources */,
+				A3CA49C61BCD9DC9004C5B45 /* DebuggerCallFrame.cpp in Sources */,
+				A3CA49C71BCD9DC9004C5B45 /* DeferGC.cpp in Sources */,
+				A3CA49C81BCD9DC9004C5B45 /* DeferredCompilationCallback.cpp in Sources */,
+				A3CA49C91BCD9DC9004C5B45 /* DFGAbstractHeap.cpp in Sources */,
+				A3CA49CA1BCD9DC9004C5B45 /* DFGAbstractValue.cpp in Sources */,
+				A3CA49CB1BCD9DC9004C5B45 /* DFGArgumentsSimplificationPhase.cpp in Sources */,
+				A3CA49CC1BCD9DC9004C5B45 /* DFGArrayMode.cpp in Sources */,
+				A3CA49CD1BCD9DC9004C5B45 /* DFGAtTailAbstractState.cpp in Sources */,
+				A3CA49CE1BCD9DC9004C5B45 /* DFGBackwardsPropagationPhase.cpp in Sources */,
+				A3CA49CF1BCD9DC9004C5B45 /* DFGBasicBlock.cpp in Sources */,
+				A3CA49D01BCD9DC9004C5B45 /* DFGBinarySwitch.cpp in Sources */,
+				A3CA49D11BCD9DC9004C5B45 /* DFGBlockInsertionSet.cpp in Sources */,
+				A3CA49D21BCD9DC9004C5B45 /* DFGByteCodeParser.cpp in Sources */,
+				A3CA49D31BCD9DC9004C5B45 /* DFGCapabilities.cpp in Sources */,
+				A3CA49D41BCD9DC9004C5B45 /* DFGCFAPhase.cpp in Sources */,
+				A3CA49D51BCD9DC9004C5B45 /* DFGCFGSimplificationPhase.cpp in Sources */,
+				A3CA49D61BCD9DC9004C5B45 /* DFGClobberize.cpp in Sources */,
+				A3CA49D71BCD9DC9004C5B45 /* DFGClobberSet.cpp in Sources */,
+				A3CA49D81BCD9DC9004C5B45 /* DFGCommon.cpp in Sources */,
+				A3CA49D91BCD9DC9004C5B45 /* DFGCommonData.cpp in Sources */,
+				A3CA49DA1BCD9DC9004C5B45 /* DFGCompilationKey.cpp in Sources */,
+				A3CA49DB1BCD9DC9004C5B45 /* DFGCompilationMode.cpp in Sources */,
+				A3CA49DC1BCD9DC9004C5B45 /* DFGConstantFoldingPhase.cpp in Sources */,
+				A3CA49DD1BCD9DC9004C5B45 /* DFGCPSRethreadingPhase.cpp in Sources */,
+				A3CA49DE1BCD9DC9004C5B45 /* DFGCriticalEdgeBreakingPhase.cpp in Sources */,
+				A3CA49DF1BCD9DC9004C5B45 /* DFGCSEPhase.cpp in Sources */,
+				A3CA49E01BCD9DC9004C5B45 /* DFGDCEPhase.cpp in Sources */,
+				A3CA49E11BCD9DC9004C5B45 /* DFGDesiredIdentifiers.cpp in Sources */,
+				A3CA49E21BCD9DC9004C5B45 /* DFGDesiredStructureChains.cpp in Sources */,
+				A3CA49E31BCD9DC9004C5B45 /* DFGDesiredTransitions.cpp in Sources */,
+				A3CA49E41BCD9DC9004C5B45 /* DFGDesiredWatchpoints.cpp in Sources */,
+				A3CA49E51BCD9DC9004C5B45 /* DFGDesiredWeakReferences.cpp in Sources */,
+				A3CA49E61BCD9DC9004C5B45 /* DFGDesiredWriteBarriers.cpp in Sources */,
+				A3CA49E71BCD9DC9004C5B45 /* DFGDisassembler.cpp in Sources */,
+				A3CA49E81BCD9DC9004C5B45 /* DFGDominators.cpp in Sources */,
+				A3CA49E91BCD9DC9004C5B45 /* DFGDriver.cpp in Sources */,
+				A3CA49EA1BCD9DC9004C5B45 /* InspectorValues.cpp in Sources */,
+				A3CA49EB1BCD9DC9004C5B45 /* DFGEdge.cpp in Sources */,
+				A3CA49EC1BCD9DC9004C5B45 /* MapIteratorPrototype.cpp in Sources */,
+				A3CA49ED1BCD9DC9004C5B45 /* DFGExitProfile.cpp in Sources */,
+				A3CA49EE1BCD9DC9004C5B45 /* DFGFailedFinalizer.cpp in Sources */,
+				A3CA49EF1BCD9DC9004C5B45 /* DFGFinalizer.cpp in Sources */,
+				A3CA49F01BCD9DC9004C5B45 /* DFGFixupPhase.cpp in Sources */,
+				A3CA49F11BCD9DC9004C5B45 /* DFGFlushedAt.cpp in Sources */,
+				A3CA49F21BCD9DC9004C5B45 /* DFGFlushFormat.cpp in Sources */,
+				A3CA49F31BCD9DC9004C5B45 /* DFGFlushLivenessAnalysisPhase.cpp in Sources */,
+				A3CA49F41BCD9DC9004C5B45 /* DFGGraph.cpp in Sources */,
+				A3CA49F51BCD9DC9004C5B45 /* DFGInPlaceAbstractState.cpp in Sources */,
+				A3CA49F61BCD9DC9004C5B45 /* DFGInvalidationPointInjectionPhase.cpp in Sources */,
+				A3CA49F71BCD9DC9004C5B45 /* DFGJITCode.cpp in Sources */,
+				A3CA49F81BCD9DC9004C5B45 /* DFGJITCompiler.cpp in Sources */,
+				A3CA49F91BCD9DC9004C5B45 /* DFGJITFinalizer.cpp in Sources */,
+				A3CA49FA1BCD9DC9004C5B45 /* DFGJumpReplacement.cpp in Sources */,
+				A3CA49FB1BCD9DC9004C5B45 /* DFGLazyJSValue.cpp in Sources */,
+				A3CA49FC1BCD9DC9004C5B45 /* DFGLICMPhase.cpp in Sources */,
+				A3CA49FD1BCD9DC9004C5B45 /* DFGLivenessAnalysisPhase.cpp in Sources */,
+				A3CA49FE1BCD9DC9004C5B45 /* DFGLongLivedState.cpp in Sources */,
+				A3CA49FF1BCD9DC9004C5B45 /* DFGLoopPreHeaderCreationPhase.cpp in Sources */,
+				A3CA4A001BCD9DC9004C5B45 /* DFGMinifiedNode.cpp in Sources */,
+				A3CA4A011BCD9DC9004C5B45 /* DFGNaturalLoops.cpp in Sources */,
+				A3CA4A021BCD9DC9004C5B45 /* DFGNode.cpp in Sources */,
+				A3CA4A031BCD9DC9004C5B45 /* DFGNodeFlags.cpp in Sources */,
+				A3CA4A041BCD9DC9004C5B45 /* DFGOperations.cpp in Sources */,
+				A3CA4A051BCD9DC9004C5B45 /* DFGOSRAvailabilityAnalysisPhase.cpp in Sources */,
+				A3CA4A061BCD9DC9004C5B45 /* DFGOSREntry.cpp in Sources */,
+				A3CA4A071BCD9DC9004C5B45 /* DFGOSREntrypointCreationPhase.cpp in Sources */,
+				A3CA4A081BCD9DC9004C5B45 /* DFGOSRExit.cpp in Sources */,
+				A3CA4A091BCD9DC9004C5B45 /* DFGOSRExitBase.cpp in Sources */,
+				A3CA4A0A1BCD9DC9004C5B45 /* DFGOSRExitCompiler.cpp in Sources */,
+				A3CA4A0B1BCD9DC9004C5B45 /* DFGOSRExitCompiler32_64.cpp in Sources */,
+				A3CA4A0C1BCD9DC9004C5B45 /* DFGStrengthReductionPhase.cpp in Sources */,
+				A3CA4A0D1BCD9DC9004C5B45 /* DFGOSRExitCompiler64.cpp in Sources */,
+				A3CA4A0E1BCD9DC9004C5B45 /* DFGOSRExitCompilerCommon.cpp in Sources */,
+				A3CA4A0F1BCD9DC9004C5B45 /* DFGOSRExitJumpPlaceholder.cpp in Sources */,
+				A3CA4A101BCD9DC9004C5B45 /* DFGOSRExitPreparation.cpp in Sources */,
+				A3CA4A111BCD9DC9004C5B45 /* DFGPhase.cpp in Sources */,
+				A3CA4A121BCD9DC9004C5B45 /* DFGPlan.cpp in Sources */,
+				A3CA4A131BCD9DC9004C5B45 /* DFGPredictionInjectionPhase.cpp in Sources */,
+				A3CA4A141BCD9DC9004C5B45 /* DFGPredictionPropagationPhase.cpp in Sources */,
+				A3CA4A151BCD9DC9004C5B45 /* DFGSpeculativeJIT.cpp in Sources */,
+				A3CA4A161BCD9DC9004C5B45 /* DFGSpeculativeJIT32_64.cpp in Sources */,
+				A3CA4A171BCD9DC9004C5B45 /* DFGSpeculativeJIT64.cpp in Sources */,
+				A3CA4A181BCD9DC9004C5B45 /* DFGSSAConversionPhase.cpp in Sources */,
+				A3CA4A191BCD9DC9004C5B45 /* DFGStackLayoutPhase.cpp in Sources */,
+				A3CA4A1A1BCD9DC9004C5B45 /* DFGThunks.cpp in Sources */,
+				A3CA4A1B1BCD9DC9004C5B45 /* DFGTierUpCheckInjectionPhase.cpp in Sources */,
+				A3CA4A1C1BCD9DC9004C5B45 /* DFGToFTLDeferredCompilationCallback.cpp in Sources */,
+				A3CA4A1D1BCD9DC9004C5B45 /* DFGToFTLForOSREntryDeferredCompilationCallback.cpp in Sources */,
+				A3CA4A1E1BCD9DC9004C5B45 /* DFGTypeCheckHoistingPhase.cpp in Sources */,
+				A3CA4A1F1BCD9DC9004C5B45 /* DFGUnificationPhase.cpp in Sources */,
+				A3CA4A201BCD9DC9004C5B45 /* DFGUseKind.cpp in Sources */,
+				A3CA4A211BCD9DC9004C5B45 /* DFGValidate.cpp in Sources */,
+				A3CA4A221BCD9DC9004C5B45 /* ScriptFunctionCall.cpp in Sources */,
+				A3CA4A231BCD9DC9004C5B45 /* DFGValueSource.cpp in Sources */,
+				A3CA4A241BCD9DC9004C5B45 /* DFGVariableAccessDataDump.cpp in Sources */,
+				A3CA4A251BCD9DC9004C5B45 /* DFGVariableEvent.cpp in Sources */,
+				A3CA4A261BCD9DC9004C5B45 /* DFGVariableEventStream.cpp in Sources */,
+				A3CA4A271BCD9DC9004C5B45 /* DFGVirtualRegisterAllocationPhase.cpp in Sources */,
+				A3CA4A281BCD9DC9004C5B45 /* DFGWatchpointCollectionPhase.cpp in Sources */,
+				A3CA4A291BCD9DC9004C5B45 /* DFGWorklist.cpp in Sources */,
+				A3CA4A2A1BCD9DC9004C5B45 /* Disassembler.cpp in Sources */,
+				A3CA4A2B1BCD9DC9004C5B45 /* DumpContext.cpp in Sources */,
+				A3CA4A2C1BCD9DC9004C5B45 /* Error.cpp in Sources */,
+				A3CA4A2D1BCD9DC9004C5B45 /* ErrorConstructor.cpp in Sources */,
+				A3CA4A2E1BCD9DC9004C5B45 /* ErrorInstance.cpp in Sources */,
+				A3CA4A2F1BCD9DC9004C5B45 /* ErrorPrototype.cpp in Sources */,
+				A3CA4A301BCD9DC9004C5B45 /* JSTypedArray.cpp in Sources */,
+				A3CA4A311BCD9DC9004C5B45 /* ExceptionHelpers.cpp in Sources */,
+				A3CA4A321BCD9DC9004C5B45 /* Executable.cpp in Sources */,
+				A3CA4A331BCD9DC9004C5B45 /* ExecutableAllocator.cpp in Sources */,
+				A3CA4A341BCD9DC9004C5B45 /* ExecutableAllocatorFixedVMPool.cpp in Sources */,
+				A3CA4A351BCD9DC9004C5B45 /* ExecutionCounter.cpp in Sources */,
+				A3CA4A361BCD9DC9004C5B45 /* JSGlobalObjectDebuggable.cpp in Sources */,
+				A3CA4A371BCD9DC9004C5B45 /* ExitKind.cpp in Sources */,
+				A3CA4A381BCD9DC9004C5B45 /* ScriptValue.cpp in Sources */,
+				A3CA4A391BCD9DC9004C5B45 /* FTLAbstractHeap.cpp in Sources */,
+				A3CA4A3A1BCD9DC9004C5B45 /* FTLAbstractHeapRepository.cpp in Sources */,
+				A3CA4A3B1BCD9DC9004C5B45 /* FTLCapabilities.cpp in Sources */,
+				A3CA4A3C1BCD9DC9004C5B45 /* FTLCommonValues.cpp in Sources */,
+				A3CA4A3D1BCD9DC9004C5B45 /* JSPromiseDeferred.cpp in Sources */,
+				A3CA4A3E1BCD9DC9004C5B45 /* InspectorJSFrontendDispatchers.cpp in Sources */,
+				A3CA4A3F1BCD9DC9004C5B45 /* FTLCompile.cpp in Sources */,
+				A3CA4A401BCD9DC9004C5B45 /* FTLExitArgument.cpp in Sources */,
+				A3CA4A411BCD9DC9004C5B45 /* FTLExitArgumentForOperand.cpp in Sources */,
+				A3CA4A421BCD9DC9004C5B45 /* FTLExitThunkGenerator.cpp in Sources */,
+				A3CA4A431BCD9DC9004C5B45 /* FTLExitValue.cpp in Sources */,
+				A3CA4A441BCD9DC9004C5B45 /* FTLFail.cpp in Sources */,
+				A3CA4A451BCD9DC9004C5B45 /* FTLForOSREntryJITCode.cpp in Sources */,
+				A3CA4A461BCD9DC9004C5B45 /* FTLInlineCacheSize.cpp in Sources */,
+				A3CA4A471BCD9DC9004C5B45 /* FTLIntrinsicRepository.cpp in Sources */,
+				A3CA4A481BCD9DC9004C5B45 /* FTLJITCode.cpp in Sources */,
+				A3CA4A491BCD9DC9004C5B45 /* FTLJITFinalizer.cpp in Sources */,
+				A3CA4A4A1BCD9DC9004C5B45 /* FTLLink.cpp in Sources */,
+				A3CA4A4B1BCD9DC9004C5B45 /* JSMapIterator.cpp in Sources */,
+				A3CA4A4C1BCD9DC9004C5B45 /* FTLLocation.cpp in Sources */,
+				A3CA4A4D1BCD9DC9004C5B45 /* FTLLowerDFGToLLVM.cpp in Sources */,
+				A3CA4A4E1BCD9DC9004C5B45 /* FTLOSREntry.cpp in Sources */,
+				A3CA4A4F1BCD9DC9004C5B45 /* FTLOSRExit.cpp in Sources */,
+				A3CA4A501BCD9DC9004C5B45 /* FTLOSRExitCompiler.cpp in Sources */,
+				A3CA4A511BCD9DC9004C5B45 /* FTLOutput.cpp in Sources */,
+				A3CA4A521BCD9DC9004C5B45 /* FTLSaveRestore.cpp in Sources */,
+				A3CA4A531BCD9DC9004C5B45 /* FTLSlowPathCall.cpp in Sources */,
+				A3CA4A541BCD9DC9004C5B45 /* FTLSlowPathCallKey.cpp in Sources */,
+				A3CA4A551BCD9DC9004C5B45 /* FTLStackMaps.cpp in Sources */,
+				A3CA4A561BCD9DC9004C5B45 /* FTLState.cpp in Sources */,
+				A3CA4A571BCD9DC9004C5B45 /* JSPromiseFunctions.cpp in Sources */,
+				A3CA4A581BCD9DC9004C5B45 /* FTLThunks.cpp in Sources */,
+				A3CA4A591BCD9DC9004C5B45 /* InspectorBackendDispatcher.cpp in Sources */,
+				A3CA4A5A1BCD9DC9004C5B45 /* FTLValueFormat.cpp in Sources */,
+				A3CA4A5B1BCD9DC9004C5B45 /* FunctionConstructor.cpp in Sources */,
+				A3CA4A5C1BCD9DC9004C5B45 /* FunctionExecutableDump.cpp in Sources */,
+				A3CA4A5D1BCD9DC9004C5B45 /* FunctionPrototype.cpp in Sources */,
+				A3CA4A5E1BCD9DC9004C5B45 /* GCActivityCallback.cpp in Sources */,
+				A3CA4A5F1BCD9DC9004C5B45 /* GCAwareJITStubRoutine.cpp in Sources */,
+				A3CA4A601BCD9DC9004C5B45 /* GCThread.cpp in Sources */,
+				A3CA4A611BCD9DC9004C5B45 /* GCThreadSharedData.cpp in Sources */,
+				A3CA4A621BCD9DC9004C5B45 /* GetByIdStatus.cpp in Sources */,
+				A3CA4A631BCD9DC9004C5B45 /* JSPromiseReaction.cpp in Sources */,
+				A3CA4A641BCD9DC9004C5B45 /* GetterSetter.cpp in Sources */,
+				A3CA4A651BCD9DC9004C5B45 /* HandleSet.cpp in Sources */,
+				A3CA4A661BCD9DC9004C5B45 /* HandleStack.cpp in Sources */,
+				A3CA4A671BCD9DC9004C5B45 /* Heap.cpp in Sources */,
+				A3CA4A681BCD9DC9004C5B45 /* HeapStatistics.cpp in Sources */,
+				A3CA4A691BCD9DC9004C5B45 /* HeapTimer.cpp in Sources */,
+				A3CA4A6A1BCD9DC9004C5B45 /* HostCallReturnValue.cpp in Sources */,
+				A3CA4A6B1BCD9DC9004C5B45 /* Identifier.cpp in Sources */,
+				A3CA4A6C1BCD9DC9004C5B45 /* IncrementalSweeper.cpp in Sources */,
+				A3CA4A6D1BCD9DC9004C5B45 /* IndexingType.cpp in Sources */,
+				A3CA4A6E1BCD9DC9004C5B45 /* InitializeLLVM.cpp in Sources */,
+				A3CA4A6F1BCD9DC9004C5B45 /* InitializeLLVMMac.mm in Sources */,
+				A3CA4A701BCD9DC9004C5B45 /* InitializeLLVMPOSIX.cpp in Sources */,
+				A3CA4A711BCD9DC9004C5B45 /* InitializeThreading.cpp in Sources */,
+				A3CA4A721BCD9DC9004C5B45 /* InlineCallFrameSet.cpp in Sources */,
+				A3CA4A731BCD9DC9004C5B45 /* IntendedStructureChain.cpp in Sources */,
+				A3CA4A741BCD9DC9004C5B45 /* InternalFunction.cpp in Sources */,
+				A3CA4A751BCD9DC9004C5B45 /* DFGStoreBarrierElisionPhase.cpp in Sources */,
+				A3CA4A761BCD9DC9004C5B45 /* Interpreter.cpp in Sources */,
+				A3CA4A771BCD9DC9004C5B45 /* JIT.cpp in Sources */,
+				A3CA4A781BCD9DC9004C5B45 /* JITArithmetic.cpp in Sources */,
+				A3CA4A791BCD9DC9004C5B45 /* JITArithmetic32_64.cpp in Sources */,
+				A3CA4A7A1BCD9DC9004C5B45 /* JITCall.cpp in Sources */,
+				A3CA4A7B1BCD9DC9004C5B45 /* JITCall32_64.cpp in Sources */,
+				A3CA4A7C1BCD9DC9004C5B45 /* JITCode.cpp in Sources */,
+				A3CA4A7D1BCD9DC9004C5B45 /* JITDisassembler.cpp in Sources */,
+				A3CA4A7E1BCD9DC9004C5B45 /* JITExceptions.cpp in Sources */,
+				A3CA4A7F1BCD9DC9004C5B45 /* JITInlineCacheGenerator.cpp in Sources */,
+				A3CA4A801BCD9DC9004C5B45 /* JITOpcodes.cpp in Sources */,
+				A3CA4A811BCD9DC9004C5B45 /* JITOpcodes32_64.cpp in Sources */,
+				A3CA4A821BCD9DC9004C5B45 /* WriteBarrierBuffer.cpp in Sources */,
+				A3CA4A831BCD9DC9004C5B45 /* JITOperations.cpp in Sources */,
+				A3CA4A841BCD9DC9004C5B45 /* JITPropertyAccess.cpp in Sources */,
+				A3CA4A851BCD9DC9004C5B45 /* JITPropertyAccess32_64.cpp in Sources */,
+				A3CA4A861BCD9DC9004C5B45 /* JITStubRoutine.cpp in Sources */,
+				A3CA4A871BCD9DC9004C5B45 /* JITStubRoutineSet.cpp in Sources */,
+				A3CA4A881BCD9DC9004C5B45 /* JITStubs.cpp in Sources */,
+				A3CA4A891BCD9DC9004C5B45 /* JITThunks.cpp in Sources */,
+				A3CA4A8A1BCD9DC9004C5B45 /* JITToDFGDeferredCompilationCallback.cpp in Sources */,
+				A3CA4A8B1BCD9DC9004C5B45 /* JSActivation.cpp in Sources */,
+				A3CA4A8C1BCD9DC9004C5B45 /* JSAPIValueWrapper.cpp in Sources */,
+				A3CA4A8D1BCD9DC9004C5B45 /* JSAPIWrapperObject.mm in Sources */,
+				A3CA4A8E1BCD9DC9004C5B45 /* JSArgumentsIterator.cpp in Sources */,
+				A3CA4A8F1BCD9DC9004C5B45 /* JSArray.cpp in Sources */,
+				A3CA4A901BCD9DC9004C5B45 /* JSArrayBuffer.cpp in Sources */,
+				A3CA4A911BCD9DC9004C5B45 /* JSArrayBufferConstructor.cpp in Sources */,
+				A3CA4A921BCD9DC9004C5B45 /* JSArrayBufferPrototype.cpp in Sources */,
+				A3CA4A931BCD9DC9004C5B45 /* JSArrayBufferView.cpp in Sources */,
+				A3CA4A941BCD9DC9004C5B45 /* JSArrayIterator.cpp in Sources */,
+				A3CA4A951BCD9DC9004C5B45 /* JSBase.cpp in Sources */,
+				A3CA4A961BCD9DC9004C5B45 /* JSBoundFunction.cpp in Sources */,
+				A3CA4A971BCD9DC9004C5B45 /* JSCallbackConstructor.cpp in Sources */,
+				A3CA4A981BCD9DC9004C5B45 /* JSCallbackFunction.cpp in Sources */,
+				A3CA4A991BCD9DC9004C5B45 /* JSCallbackObject.cpp in Sources */,
+				A3CA4A9A1BCD9DC9004C5B45 /* JSCell.cpp in Sources */,
+				A3CA4A9B1BCD9DC9004C5B45 /* JSCJSValue.cpp in Sources */,
+				A3CA4A9C1BCD9DC9004C5B45 /* JSClassRef.cpp in Sources */,
+				A3CA4A9D1BCD9DC9004C5B45 /* JSContext.mm in Sources */,
+				A3CA4A9E1BCD9DC9004C5B45 /* JSContextRef.cpp in Sources */,
+				A3CA4A9F1BCD9DC9004C5B45 /* JSCTestRunnerUtils.cpp in Sources */,
+				A3CA4AA01BCD9DC9004C5B45 /* JSDataView.cpp in Sources */,
+				A3CA4AA11BCD9DC9004C5B45 /* JSDataViewPrototype.cpp in Sources */,
+				A3CA4AA21BCD9DC9004C5B45 /* JSDateMath.cpp in Sources */,
+				A3CA4AA31BCD9DC9004C5B45 /* JSFunction.cpp in Sources */,
+				A3CA4AA41BCD9DC9004C5B45 /* JSGlobalObject.cpp in Sources */,
+				A3CA4AA51BCD9DC9004C5B45 /* JSGlobalObjectFunctions.cpp in Sources */,
+				A3CA4AA61BCD9DC9004C5B45 /* JSLock.cpp in Sources */,
+				A3CA4AA71BCD9DC9004C5B45 /* JSManagedValue.mm in Sources */,
+				A3CA4AA81BCD9DC9004C5B45 /* JSMap.cpp in Sources */,
+				A3CA4AA91BCD9DC9004C5B45 /* JSNameScope.cpp in Sources */,
+				A3CA4AAA1BCD9DC9004C5B45 /* JSNotAnObject.cpp in Sources */,
+				A3CA4AAB1BCD9DC9004C5B45 /* JSObject.cpp in Sources */,
+				A3CA4AAC1BCD9DC9004C5B45 /* JSObjectRef.cpp in Sources */,
+				A3CA4AAD1BCD9DC9004C5B45 /* JSONObject.cpp in Sources */,
+				A3CA4AAE1BCD9DC9004C5B45 /* JSProfilerPrivate.cpp in Sources */,
+				A3CA4AAF1BCD9DC9004C5B45 /* JSPromise.cpp in Sources */,
+				A3CA4AB01BCD9DC9004C5B45 /* JSPromiseConstructor.cpp in Sources */,
+				A3CA4AB11BCD9DC9004C5B45 /* JSPromisePrototype.cpp in Sources */,
+				A3CA4AB21BCD9DC9004C5B45 /* JSPropertyNameIterator.cpp in Sources */,
+				A3CA4AB31BCD9DC9004C5B45 /* JSProxy.cpp in Sources */,
+				A3CA4AB41BCD9DC9004C5B45 /* JSScope.cpp in Sources */,
+				A3CA4AB51BCD9DC9004C5B45 /* JSScriptRef.cpp in Sources */,
+				A3CA4AB61BCD9DC9004C5B45 /* JSSegmentedVariableObject.cpp in Sources */,
+				A3CA4AB71BCD9DC9004C5B45 /* JSSet.cpp in Sources */,
+				A3CA4AB81BCD9DC9004C5B45 /* JSStack.cpp in Sources */,
+				A3CA4AB91BCD9DC9004C5B45 /* JSString.cpp in Sources */,
+				A3CA4ABA1BCD9DC9004C5B45 /* JSStringJoiner.cpp in Sources */,
+				A3CA4ABB1BCD9DC9004C5B45 /* ArrayBufferNeuteringWatchpoint.cpp in Sources */,
+				A3CA4ABC1BCD9DC9004C5B45 /* JSStringRef.cpp in Sources */,
+				A3CA4ABD1BCD9DC9004C5B45 /* JSStringRefCF.cpp in Sources */,
+				A3CA4ABE1BCD9DC9004C5B45 /* JSSymbolTableObject.cpp in Sources */,
+				A3CA4ABF1BCD9DC9004C5B45 /* JSTypedArrayConstructors.cpp in Sources */,
+				A3CA4AC01BCD9DC9004C5B45 /* InspectorJSTypeBuilders.cpp in Sources */,
+				A3CA4AC11BCD9DC9004C5B45 /* JSTypedArrayPrototypes.cpp in Sources */,
+				A3CA4AC21BCD9DC9004C5B45 /* JSTypedArrays.cpp in Sources */,
+				A3CA4AC31BCD9DC9004C5B45 /* JSValue.mm in Sources */,
+				A3CA4AC41BCD9DC9004C5B45 /* JSValueRef.cpp in Sources */,
+				A3CA4AC51BCD9DC9004C5B45 /* JSVariableObject.cpp in Sources */,
+				A3CA4AC61BCD9DC9004C5B45 /* JSVirtualMachine.mm in Sources */,
+				A3CA4AC71BCD9DC9004C5B45 /* VMEntryScope.cpp in Sources */,
+				A3CA4AC81BCD9DC9004C5B45 /* JSWeakMap.cpp in Sources */,
+				A3CA4AC91BCD9DC9004C5B45 /* JSWeakObjectMapRefPrivate.cpp in Sources */,
+				A3CA4ACA1BCD9DC9004C5B45 /* JSWithScope.cpp in Sources */,
+				A3CA4ACB1BCD9DC9004C5B45 /* JSWrapperMap.mm in Sources */,
+				A3CA4ACC1BCD9DC9004C5B45 /* JSWrapperObject.cpp in Sources */,
+				A3CA4ACD1BCD9DC9004C5B45 /* JumpTable.cpp in Sources */,
+				A3CA4ACE1BCD9DC9004C5B45 /* LazyOperandValueProfile.cpp in Sources */,
+				A3CA4ACF1BCD9DC9004C5B45 /* LegacyProfiler.cpp in Sources */,
+				A3CA4AD01BCD9DC9004C5B45 /* Lexer.cpp in Sources */,
+				A3CA4AD11BCD9DC9004C5B45 /* LinkBuffer.cpp in Sources */,
+				A3CA4AD21BCD9DC9004C5B45 /* LiteralParser.cpp in Sources */,
+				A3CA4AD31BCD9DC9004C5B45 /* LLIntCLoop.cpp in Sources */,
+				A3CA4AD41BCD9DC9004C5B45 /* LLIntData.cpp in Sources */,
+				A3CA4AD51BCD9DC9004C5B45 /* LLIntEntrypoint.cpp in Sources */,
+				A3CA4AD61BCD9DC9004C5B45 /* LLIntExceptions.cpp in Sources */,
+				A3CA4AD71BCD9DC9004C5B45 /* LLIntSlowPaths.cpp in Sources */,
+				A3CA4AD81BCD9DC9004C5B45 /* LLIntThunks.cpp in Sources */,
+				A3CA4AD91BCD9DC9004C5B45 /* LLVMAPI.cpp in Sources */,
+				A3CA4ADA1BCD9DC9004C5B45 /* LLVMDisassembler.cpp in Sources */,
+				A3CA4ADB1BCD9DC9004C5B45 /* Lookup.cpp in Sources */,
+				A3CA4ADC1BCD9DC9004C5B45 /* LowLevelInterpreter.cpp in Sources */,
+				A3CA4ADD1BCD9DC9004C5B45 /* MachineStackMarker.cpp in Sources */,
+				A3CA4ADE1BCD9DC9004C5B45 /* RemoteInspectorDebuggable.cpp in Sources */,
+				A3CA4ADF1BCD9DC9004C5B45 /* MacroAssembler.cpp in Sources */,
+				A3CA4AE01BCD9DC9004C5B45 /* MacroAssemblerARM.cpp in Sources */,
+				A3CA4AE11BCD9DC9004C5B45 /* MacroAssemblerARMv7.cpp in Sources */,
+				A3CA4AE21BCD9DC9004C5B45 /* InspectorJSBackendDispatchers.cpp in Sources */,
+				A3CA4AE31BCD9DC9004C5B45 /* MacroAssemblerX86Common.cpp in Sources */,
+				A3CA4AE41BCD9DC9004C5B45 /* MapConstructor.cpp in Sources */,
+				A3CA4AE51BCD9DC9004C5B45 /* MapData.cpp in Sources */,
+				A3CA4AE61BCD9DC9004C5B45 /* MapPrototype.cpp in Sources */,
+				A3CA4AE71BCD9DC9004C5B45 /* MarkedAllocator.cpp in Sources */,
+				A3CA4AE81BCD9DC9004C5B45 /* MarkedBlock.cpp in Sources */,
+				A3CA4AE91BCD9DC9004C5B45 /* MarkedSpace.cpp in Sources */,
+				A3CA4AEA1BCD9DC9004C5B45 /* MarkStack.cpp in Sources */,
+				A3CA4AEB1BCD9DC9004C5B45 /* MathObject.cpp in Sources */,
+				A3CA4AEC1BCD9DC9004C5B45 /* MemoryStatistics.cpp in Sources */,
+				A3CA4AED1BCD9DC9004C5B45 /* MethodOfGettingAValueProfile.cpp in Sources */,
+				A3CA4AEE1BCD9DC9004C5B45 /* NameConstructor.cpp in Sources */,
+				A3CA4AEF1BCD9DC9004C5B45 /* NameInstance.cpp in Sources */,
+				A3CA4AF01BCD9DC9004C5B45 /* NamePrototype.cpp in Sources */,
+				A3CA4AF11BCD9DC9004C5B45 /* ScriptObject.cpp in Sources */,
+				A3CA4AF21BCD9DC9004C5B45 /* NativeErrorConstructor.cpp in Sources */,
+				A3CA4AF31BCD9DC9004C5B45 /* NativeErrorPrototype.cpp in Sources */,
+				A3CA4AF41BCD9DC9004C5B45 /* Nodes.cpp in Sources */,
+				A3CA4AF51BCD9DC9004C5B45 /* NodesCodegen.cpp in Sources */,
+				A3CA4AF61BCD9DC9004C5B45 /* NumberConstructor.cpp in Sources */,
+				A3CA4AF71BCD9DC9004C5B45 /* NumberObject.cpp in Sources */,
+				A3CA4AF81BCD9DC9004C5B45 /* NumberPrototype.cpp in Sources */,
+				A3CA4AF91BCD9DC9004C5B45 /* ObjCCallbackFunction.mm in Sources */,
+				A3CA4AFA1BCD9DC9004C5B45 /* ObjectConstructor.cpp in Sources */,
+				A3CA4AFB1BCD9DC9004C5B45 /* ObjectPrototype.cpp in Sources */,
+				A3CA4AFC1BCD9DC9004C5B45 /* OpaqueJSString.cpp in Sources */,
+				A3CA4AFD1BCD9DC9004C5B45 /* Opcode.cpp in Sources */,
+				A3CA4AFE1BCD9DC9004C5B45 /* Operations.cpp in Sources */,
+				A3CA4AFF1BCD9DC9004C5B45 /* Options.cpp in Sources */,
+				A3CA4B001BCD9DC9004C5B45 /* DFGSSALoweringPhase.cpp in Sources */,
+				A3CA4B011BCD9DC9004C5B45 /* Parser.cpp in Sources */,
+				A3CA4B021BCD9DC9004C5B45 /* ParserArena.cpp in Sources */,
+				A3CA4B031BCD9DC9004C5B45 /* PolymorphicPutByIdList.cpp in Sources */,
+				A3CA4B041BCD9DC9004C5B45 /* PreciseJumpTargets.cpp in Sources */,
+				A3CA4B051BCD9DC9004C5B45 /* Profile.cpp in Sources */,
+				A3CA4B061BCD9DC9004C5B45 /* ProfiledCodeBlockJettisoningWatchpoint.cpp in Sources */,
+				A3CA4B071BCD9DC9004C5B45 /* ProfileGenerator.cpp in Sources */,
+				A3CA4B081BCD9DC9004C5B45 /* ProfileNode.cpp in Sources */,
+				A3CA4B091BCD9DC9004C5B45 /* ProfilerBytecode.cpp in Sources */,
+				A3CA4B0A1BCD9DC9004C5B45 /* ProfilerBytecodes.cpp in Sources */,
+				A3CA4B0B1BCD9DC9004C5B45 /* ProfilerBytecodeSequence.cpp in Sources */,
+				A3CA4B0C1BCD9DC9004C5B45 /* ProfilerCompilation.cpp in Sources */,
+				A3CA4B0D1BCD9DC9004C5B45 /* ProfilerCompilationKind.cpp in Sources */,
+				A3CA4B0E1BCD9DC9004C5B45 /* ProfilerCompiledBytecode.cpp in Sources */,
+				A3CA4B0F1BCD9DC9004C5B45 /* ProfilerDatabase.cpp in Sources */,
+				A3CA4B101BCD9DC9004C5B45 /* ProfilerOrigin.cpp in Sources */,
+				A3CA4B111BCD9DC9004C5B45 /* ProfilerOriginStack.cpp in Sources */,
+				A3CA4B121BCD9DC9004C5B45 /* BytecodeBasicBlock.cpp in Sources */,
+				A3CA4B131BCD9DC9004C5B45 /* DFGResurrectionForValidationPhase.cpp in Sources */,
+				A3CA4B141BCD9DC9004C5B45 /* ProfilerOSRExit.cpp in Sources */,
+				A3CA4B151BCD9DC9004C5B45 /* ProfilerOSRExitSite.cpp in Sources */,
+				A3CA4B161BCD9DC9004C5B45 /* ProfilerProfiledBytecodes.cpp in Sources */,
+				A3CA4B171BCD9DC9004C5B45 /* PropertyDescriptor.cpp in Sources */,
+				A3CA4B181BCD9DC9004C5B45 /* PropertyNameArray.cpp in Sources */,
+				A3CA4B191BCD9DC9004C5B45 /* PropertySlot.cpp in Sources */,
+				A3CA4B1A1BCD9DC9004C5B45 /* PropertyTable.cpp in Sources */,
+				A3CA4B1B1BCD9DC9004C5B45 /* PrototypeMap.cpp in Sources */,
+				A3CA4B1C1BCD9DC9004C5B45 /* PutByIdStatus.cpp in Sources */,
+				A3CA4B1D1BCD9DC9004C5B45 /* ReduceWhitespace.cpp in Sources */,
+				A3CA4B1E1BCD9DC9004C5B45 /* RegExp.cpp in Sources */,
+				A3CA4B1F1BCD9DC9004C5B45 /* RegExpCache.cpp in Sources */,
+				A3CA4B201BCD9DC9004C5B45 /* RegExpCachedResult.cpp in Sources */,
+				A3CA4B211BCD9DC9004C5B45 /* RegExpConstructor.cpp in Sources */,
+				A3CA4B221BCD9DC9004C5B45 /* RegExpMatchesArray.cpp in Sources */,
+				A3CA4B231BCD9DC9004C5B45 /* RegExpObject.cpp in Sources */,
+				A3CA4B241BCD9DC9004C5B45 /* RegExpPrototype.cpp in Sources */,
+				A3CA4B251BCD9DC9004C5B45 /* RegisterSet.cpp in Sources */,
+				A3CA4B261BCD9DC9004C5B45 /* Repatch.cpp in Sources */,
+				A3CA4B271BCD9DC9004C5B45 /* SamplingCounter.cpp in Sources */,
+				A3CA4B281BCD9DC9004C5B45 /* SamplingTool.cpp in Sources */,
+				A3CA4B291BCD9DC9004C5B45 /* SetConstructor.cpp in Sources */,
+				A3CA4B2A1BCD9DC9004C5B45 /* SetPrototype.cpp in Sources */,
+				A3CA4B2B1BCD9DC9004C5B45 /* SimpleTypedArrayController.cpp in Sources */,
+				A3CA4B2C1BCD9DC9004C5B45 /* SetIteratorPrototype.cpp in Sources */,
+				A3CA4B2D1BCD9DC9004C5B45 /* SlotVisitor.cpp in Sources */,
+				A3CA4B2E1BCD9DC9004C5B45 /* SmallStrings.cpp in Sources */,
+				A3CA4B2F1BCD9DC9004C5B45 /* SourceCode.cpp in Sources */,
+				A3CA4B301BCD9DC9004C5B45 /* SourceProvider.cpp in Sources */,
+				A3CA4B311BCD9DC9004C5B45 /* SourceProviderCache.cpp in Sources */,
+				A3CA4B321BCD9DC9004C5B45 /* SparseArrayValueMap.cpp in Sources */,
+				A3CA4B331BCD9DC9004C5B45 /* SpecialPointer.cpp in Sources */,
+				A3CA4B341BCD9DC9004C5B45 /* SpeculatedType.cpp in Sources */,
+				A3CA4B351BCD9DC9004C5B45 /* StackVisitor.cpp in Sources */,
+				A3CA4B361BCD9DC9004C5B45 /* StrictEvalActivation.cpp in Sources */,
+				A3CA4B371BCD9DC9004C5B45 /* StringConstructor.cpp in Sources */,
+				A3CA4B381BCD9DC9004C5B45 /* StringObject.cpp in Sources */,
+				A3CA4B391BCD9DC9004C5B45 /* StringPrototype.cpp in Sources */,
+				A3CA4B3A1BCD9DC9004C5B45 /* StringRecursionChecker.cpp in Sources */,
+				A3CA4B3B1BCD9DC9004C5B45 /* Structure.cpp in Sources */,
+				A3CA4B3C1BCD9DC9004C5B45 /* StructureChain.cpp in Sources */,
+				A3CA4B3D1BCD9DC9004C5B45 /* StructureRareData.cpp in Sources */,
+				A3CA4B3E1BCD9DC9004C5B45 /* StructureStubClearingWatchpoint.cpp in Sources */,
+				A3CA4B3F1BCD9DC9004C5B45 /* StructureStubInfo.cpp in Sources */,
+				A3CA4B401BCD9DC9004C5B45 /* MapIteratorConstructor.cpp in Sources */,
+				A3CA4B411BCD9DC9004C5B45 /* SuperRegion.cpp in Sources */,
+				A3CA4B421BCD9DC9004C5B45 /* SymbolTable.cpp in Sources */,
+				A3CA4B431BCD9DC9004C5B45 /* TempRegisterSet.cpp in Sources */,
+				A3CA4B441BCD9DC9004C5B45 /* TestRunnerUtils.cpp in Sources */,
+				A3CA4B451BCD9DC9004C5B45 /* ThunkGenerators.cpp in Sources */,
+				A3CA4B461BCD9DC9004C5B45 /* TypedArrayController.cpp in Sources */,
+				A3CA4B471BCD9DC9004C5B45 /* TypedArrayType.cpp in Sources */,
+				A3CA4B481BCD9DC9004C5B45 /* udis86.c in Sources */,
+				A3CA4B491BCD9DC9004C5B45 /* udis86_decode.c in Sources */,
+				A3CA4B4A1BCD9DC9004C5B45 /* SetIteratorConstructor.cpp in Sources */,
+				A3CA4B4B1BCD9DC9004C5B45 /* udis86_input.c in Sources */,
+				A3CA4B4C1BCD9DC9004C5B45 /* udis86_itab_holder.c in Sources */,
+				A3CA4B4D1BCD9DC9004C5B45 /* udis86_syn-att.c in Sources */,
+				A3CA4B4E1BCD9DC9004C5B45 /* udis86_syn-intel.c in Sources */,
+				A3CA4B4F1BCD9DC9004C5B45 /* udis86_syn.c in Sources */,
+				A3CA4B501BCD9DC9004C5B45 /* UDis86Disassembler.cpp in Sources */,
+				A3CA4B511BCD9DC9004C5B45 /* UnlinkedCodeBlock.cpp in Sources */,
+				A3CA4B521BCD9DC9004C5B45 /* ValueRecovery.cpp in Sources */,
+				A3CA4B531BCD9DC9004C5B45 /* VM.cpp in Sources */,
+				A3CA4B541BCD9DC9004C5B45 /* VMInspector.cpp in Sources */,
+				A3CA4B551BCD9DC9004C5B45 /* Watchdog.cpp in Sources */,
+				A3CA4B561BCD9DC9004C5B45 /* WatchdogMac.cpp in Sources */,
+				A3CA4B571BCD9DC9004C5B45 /* DFGAvailability.cpp in Sources */,
+				A3CA4B581BCD9DC9004C5B45 /* Watchpoint.cpp in Sources */,
+				A3CA4B591BCD9DC9004C5B45 /* Weak.cpp in Sources */,
+				A3CA4B5A1BCD9DC9004C5B45 /* WeakBlock.cpp in Sources */,
+				A3CA4B5B1BCD9DC9004C5B45 /* WeakHandleOwner.cpp in Sources */,
+				A3CA4B5C1BCD9DC9004C5B45 /* WeakMapConstructor.cpp in Sources */,
+				A3CA4B5D1BCD9DC9004C5B45 /* WeakMapData.cpp in Sources */,
+				A3CA4B5E1BCD9DC9004C5B45 /* WeakMapPrototype.cpp in Sources */,
+				A3CA4B5F1BCD9DC9004C5B45 /* WeakSet.cpp in Sources */,
+				A3CA4B601BCD9DC9004C5B45 /* WriteBarrierSupport.cpp in Sources */,
+				A3CA4B611BCD9DC9004C5B45 /* RemoteInspector.mm in Sources */,
+				A3CA4B621BCD9DC9004C5B45 /* RemoteInspectorDebuggableConnection.mm in Sources */,
+				A3CA4B631BCD9DC9004C5B45 /* RemoteInspectorXPCConnection.mm in Sources */,
+				A3CA4B641BCD9DC9004C5B45 /* X86Disassembler.cpp in Sources */,
+				A3CA4B651BCD9DC9004C5B45 /* YarrCanonicalizeUCS2.cpp in Sources */,
+				A3CA4B661BCD9DC9004C5B45 /* YarrInterpreter.cpp in Sources */,
+				A3CA4B671BCD9DC9004C5B45 /* YarrJIT.cpp in Sources */,
+				A3CA4B681BCD9DC9004C5B45 /* YarrPattern.cpp in Sources */,
+				A3CA4B691BCD9DC9004C5B45 /* InspectorAgentRegistry.cpp in Sources */,
+				A3CA4B6A1BCD9DC9004C5B45 /* YarrSyntaxChecker.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -8702,6 +11267,11 @@
 			isa = PBXTargetDependency;
 			target = 932F5B3E0822A1C700736975 /* JavaScriptCore */;
 			targetProxy = 932F5BE60822A1C700736975 /* PBXContainerItemProxy */;
+		};
+		A3CA46B21BCD9DC9004C5B45 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 10D592F61889C55E00C05A0D /* Derived Sources iOS */;
+			targetProxy = A3CA46B31BCD9DC9004C5B45 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -8813,7 +11383,7 @@
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				PRODUCT_NAME = JSCLLIntOffsetsExtractor;
 				SDKROOT = iphoneos7.0;
-				VALID_ARCHS = "armv7 armv7s arm64";
+				VALID_ARCHS = "armv7 armv7s arm64 x86_64";
 			};
 			name = Debug;
 		};
@@ -8824,7 +11394,7 @@
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				PRODUCT_NAME = JSCLLIntOffsetsExtractor;
 				SDKROOT = iphoneos7.0;
-				VALID_ARCHS = "armv7 armv7s arm64";
+				VALID_ARCHS = "armv7 armv7s arm64 x86_64";
 			};
 			name = Release;
 		};
@@ -8835,7 +11405,7 @@
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				PRODUCT_NAME = JSCLLIntOffsetsExtractor;
 				SDKROOT = iphoneos7.0;
-				VALID_ARCHS = "armv7 armv7s arm64";
+				VALID_ARCHS = "armv7 armv7s arm64 x86_64";
 			};
 			name = Profiling;
 		};
@@ -8846,7 +11416,7 @@
 				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
 				PRODUCT_NAME = JSCLLIntOffsetsExtractor;
 				SDKROOT = iphoneos7.0;
-				VALID_ARCHS = "armv7 armv7s arm64";
+				VALID_ARCHS = "armv7 armv7s arm64 x86_64";
 			};
 			name = Production;
 		};
@@ -9192,6 +11762,85 @@
 			};
 			name = Production;
 		};
+		A3CA4B741BCD9DC9004C5B45 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 10EAA6FF1889E6B300DEB161 /* JavaScriptCore-iOS-Static.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				INFOPLIST_FILE = Info.plist;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-ledit",
+					"-licucore",
+					"-lobjc",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				VALID_ARCHS = arm64;
+			};
+			name = Debug;
+		};
+		A3CA4B751BCD9DC9004C5B45 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 10EAA6FF1889E6B300DEB161 /* JavaScriptCore-iOS-Static.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				INFOPLIST_FILE = Info.plist;
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-ledit",
+					"-licucore",
+					"-lobjc",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				VALID_ARCHS = arm64;
+			};
+			name = Release;
+		};
+		A3CA4B761BCD9DC9004C5B45 /* Profiling */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 10EAA6FF1889E6B300DEB161 /* JavaScriptCore-iOS-Static.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				INFOPLIST_FILE = Info.plist;
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-ledit",
+					"-licucore",
+					"-lobjc",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				VALID_ARCHS = arm64;
+			};
+			name = Profiling;
+		};
+		A3CA4B771BCD9DC9004C5B45 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 10EAA6FF1889E6B300DEB161 /* JavaScriptCore-iOS-Static.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD)";
+				BUILD_VARIANTS = normal;
+				INFOPLIST_FILE = Info.plist;
+				ONLY_ACTIVE_ARCH = NO;
+				OTHER_LDFLAGS = (
+					"-lz",
+					"-ledit",
+					"-licucore",
+					"-lobjc",
+				);
+				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+				VALID_ARCHS = arm64;
+			};
+			name = Production;
+		};
 		A761483D0E6402F700E357FA /* Profiling */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 1C9051440BA9E8A70081E9D0 /* DebugRelease.xcconfig */;
@@ -9415,6 +12064,17 @@
 				65FB3F7909D11EBD00F49DEB /* Release */,
 				A76148400E6402F700E357FA /* Profiling */,
 				65FB3F7A09D11EBD00F49DEB /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		A3CA4B731BCD9DC9004C5B45 /* Build configuration list for PBXNativeTarget "JavaScriptCore tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A3CA4B741BCD9DC9004C5B45 /* Debug */,
+				A3CA4B751BCD9DC9004C5B45 /* Release */,
+				A3CA4B761BCD9DC9004C5B45 /* Profiling */,
+				A3CA4B771BCD9DC9004C5B45 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/All.xcscheme
+++ b/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/All.xcscheme
@@ -23,30 +23,42 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "932F5BE30822A1C700736975"
+            BuildableName = "All"
+            BlueprintName = "All"
+            ReferencedContainer = "container:JavaScriptCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore iOS.xcscheme
+++ b/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore iOS.xcscheme
@@ -23,30 +23,42 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "10D58E0D1889C3DF00C05A0D"
+            BuildableName = "libJavaScriptCore.a"
+            BlueprintName = "JavaScriptCore iOS"
+            ReferencedContainer = "container:JavaScriptCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore tvOS.xcscheme
+++ b/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3CA46B11BCD9DC9004C5B45"
+               BuildableName = "libJavaScriptCore-tvOS.a"
+               BlueprintName = "JavaScriptCore tvOS"
+               ReferencedContainer = "container:JavaScriptCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3CA46B11BCD9DC9004C5B45"
+            BuildableName = "libJavaScriptCore-tvOS.a"
+            BlueprintName = "JavaScriptCore tvOS"
+            ReferencedContainer = "container:JavaScriptCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3CA46B11BCD9DC9004C5B45"
+            BuildableName = "libJavaScriptCore-tvOS.a"
+            BlueprintName = "JavaScriptCore tvOS"
+            ReferencedContainer = "container:JavaScriptCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore.xcscheme
+++ b/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/JavaScriptCore.xcscheme
@@ -23,30 +23,42 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "932F5B3E0822A1C700736975"
+            BuildableName = "JavaScriptCore.framework"
+            BlueprintName = "JavaScriptCore"
+            ReferencedContainer = "container:JavaScriptCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
    </ProfileAction>
    <AnalyzeAction

--- a/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/jsc.xcscheme
+++ b/JavaScriptCore/JavaScriptCore.xcodeproj/xcshareddata/xcschemes/jsc.xcscheme
@@ -23,10 +23,10 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
       </Testables>
       <MacroExpansion>
@@ -38,17 +38,21 @@
             ReferencedContainer = "container:JavaScriptCore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "932F5BDA0822A1C700736975"
@@ -61,12 +65,13 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
-      <BuildableProductRunnable>
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "932F5BDA0822A1C700736975"

--- a/WTF/WTF.xcodeproj/project.pbxproj
+++ b/WTF/WTF.xcodeproj/project.pbxproj
@@ -270,10 +270,266 @@
 		10EAA8021889E93100DEB161 /* WebCoreThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA47C89152502DA00568D1B /* WebCoreThread.h */; };
 		10EAA8031889E93100DEB161 /* WTFString.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4732E151A825B004123FF /* WTFString.h */; };
 		10EAA8041889E93100DEB161 /* WTFThreadData.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4737B151A825B004123FF /* WTFThreadData.h */; };
+		A3CA45B11BCD9D70004C5B45 /* Assertions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4725B151A825A004123FF /* Assertions.cpp */; };
+		A3CA45B21BCD9D70004C5B45 /* AtomicString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4731D151A825B004123FF /* AtomicString.cpp */; };
+		A3CA45B31BCD9D70004C5B45 /* AtomicStringTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 9BC70F04176C379D00101DEC /* AtomicStringTable.cpp */; };
+		A3CA45B41BCD9D70004C5B45 /* StringCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F8182435A600A82E69 /* StringCF.cpp */; };
+		A3CA45B51BCD9D70004C5B45 /* AutodrainedPoolMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1469419B16EAB10A0024E146 /* AutodrainedPoolMac.mm */; };
+		A3CA45B61BCD9D70004C5B45 /* Base64.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8134013615B092FD001FF0B8 /* Base64.cpp */; };
+		A3CA45B71BCD9D70004C5B45 /* bignum-dtoa.cc in Sources */ = {isa = PBXBuildFile; fileRef = A8A47282151A825A004123FF /* bignum-dtoa.cc */; };
+		A3CA45B81BCD9D70004C5B45 /* bignum.cc in Sources */ = {isa = PBXBuildFile; fileRef = A8A47284151A825A004123FF /* bignum.cc */; };
+		A3CA45B91BCD9D70004C5B45 /* BinarySemaphore.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4733A151A825B004123FF /* BinarySemaphore.cpp */; };
+		A3CA45BA1BCD9D70004C5B45 /* BitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47260151A825A004123FF /* BitVector.cpp */; };
+		A3CA45BB1BCD9D70004C5B45 /* cached-powers.cc in Sources */ = {isa = PBXBuildFile; fileRef = A8A47286151A825A004123FF /* cached-powers.cc */; };
+		A3CA45BC1BCD9D70004C5B45 /* CollatorDefault.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4734B151A825B004123FF /* CollatorDefault.cpp */; };
+		A3CA45BD1BCD9D70004C5B45 /* CollatorICU.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47350151A825B004123FF /* CollatorICU.cpp */; };
+		A3CA45BE1BCD9D70004C5B45 /* CompilationThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F8F2B8F172E00F0007DBDA5 /* CompilationThread.cpp */; };
+		A3CA45BF1BCD9D70004C5B45 /* Compression.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A7E643C417C5423B003BB16B /* Compression.cpp */; };
+		A3CA45C01BCD9D70004C5B45 /* CryptographicallyRandomNumber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47273151A825A004123FF /* CryptographicallyRandomNumber.cpp */; };
+		A3CA45C11BCD9D70004C5B45 /* CString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47321151A825B004123FF /* CString.cpp */; };
+		A3CA45C21BCD9D70004C5B45 /* CurrentTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47275151A825A004123FF /* CurrentTime.cpp */; };
+		A3CA45C31BCD9D70004C5B45 /* DataLog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47277151A825A004123FF /* DataLog.cpp */; };
+		A3CA45C41BCD9D70004C5B45 /* DateMath.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47279151A825A004123FF /* DateMath.cpp */; };
+		A3CA45C51BCD9D70004C5B45 /* DecimalNumber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4727B151A825A004123FF /* DecimalNumber.cpp */; };
+		A3CA45C61BCD9D70004C5B45 /* diy-fp.cc in Sources */ = {isa = PBXBuildFile; fileRef = A8A47289151A825A004123FF /* diy-fp.cc */; };
+		A3CA45C71BCD9D70004C5B45 /* double-conversion.cc in Sources */ = {isa = PBXBuildFile; fileRef = A8A4728B151A825A004123FF /* double-conversion.cc */; };
+		A3CA45C81BCD9D70004C5B45 /* dtoa.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47297151A825A004123FF /* dtoa.cpp */; };
+		A3CA45C91BCD9D70004C5B45 /* FastBitVector.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F885E0E1845AE9F00F1E3FA /* FastBitVector.cpp */; };
+		A3CA45CA1BCD9D70004C5B45 /* DynamicAnnotations.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47299151A825A004123FF /* DynamicAnnotations.cpp */; };
+		A3CA45CB1BCD9D70004C5B45 /* fast-dtoa.cc in Sources */ = {isa = PBXBuildFile; fileRef = A8A4728E151A825A004123FF /* fast-dtoa.cc */; };
+		A3CA45CC1BCD9D70004C5B45 /* FastMalloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472A1151A825A004123FF /* FastMalloc.cpp */; };
+		A3CA45CD1BCD9D70004C5B45 /* StringImplCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F9182435A600A82E69 /* StringImplCF.cpp */; };
+		A3CA45CE1BCD9D70004C5B45 /* AtomicStringCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F7182435A600A82E69 /* AtomicStringCF.cpp */; };
+		A3CA45CF1BCD9D70004C5B45 /* FilePrintStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D335B165DBA73005AD387 /* FilePrintStream.cpp */; };
+		A3CA45D01BCD9D70004C5B45 /* fixed-dtoa.cc in Sources */ = {isa = PBXBuildFile; fileRef = A8A47290151A825A004123FF /* fixed-dtoa.cc */; };
+		A3CA45D11BCD9D70004C5B45 /* FunctionDispatcher.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1A1D8B9D1731879800141DA4 /* FunctionDispatcher.cpp */; };
+		A3CA45D21BCD9D70004C5B45 /* GregorianDateTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CCD892915C0390200285083 /* GregorianDateTime.cpp */; };
+		A3CA45D31BCD9D70004C5B45 /* HashTable.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472B8151A825A004123FF /* HashTable.cpp */; };
+		A3CA45D41BCD9D70004C5B45 /* MainThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472C6151A825A004123FF /* MainThread.cpp */; };
+		A3CA45D51BCD9D70004C5B45 /* MainThreadMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = A8A472C5151A825A004123FF /* MainThreadMac.mm */; };
+		A3CA45D61BCD9D70004C5B45 /* MD5.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472CA151A825B004123FF /* MD5.cpp */; };
+		A3CA45D71BCD9D70004C5B45 /* MediaTime.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CD5497AA15857D0300B5BC30 /* MediaTime.cpp */; };
+		A3CA45D81BCD9D70004C5B45 /* MetaAllocator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472CD151A825B004123FF /* MetaAllocator.cpp */; };
+		A3CA45D91BCD9D70004C5B45 /* NumberOfCores.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472D5151A825B004123FF /* NumberOfCores.cpp */; };
+		A3CA45DA1BCD9D70004C5B45 /* OSAllocatorPosix.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472D8151A825B004123FF /* OSAllocatorPosix.cpp */; };
+		A3CA45DB1BCD9D70004C5B45 /* OSRandomSource.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472DA151A825B004123FF /* OSRandomSource.cpp */; };
+		A3CA45DC1BCD9D70004C5B45 /* PageAllocationAligned.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472E1151A825B004123FF /* PageAllocationAligned.cpp */; };
+		A3CA45DD1BCD9D70004C5B45 /* PageBlock.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472E3151A825B004123FF /* PageBlock.cpp */; };
+		A3CA45DE1BCD9D70004C5B45 /* PrintStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0F9D335D165DBA73005AD387 /* PrintStream.cpp */; };
+		A3CA45DF1BCD9D70004C5B45 /* StringImplMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F41824348000A82E69 /* StringImplMac.mm */; };
+		A3CA45E01BCD9D70004C5B45 /* RAMSize.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 143F611D1565F0F900DB514A /* RAMSize.cpp */; };
+		A3CA45E11BCD9D70004C5B45 /* RandomNumber.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A472FB151A825B004123FF /* RandomNumber.cpp */; };
+		A3CA45E21BCD9D70004C5B45 /* RefCountedLeakCounter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47301151A825B004123FF /* RefCountedLeakCounter.cpp */; };
+		A3CA45E31BCD9D70004C5B45 /* RunLoop.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CDED0F118115C85004DBA70 /* RunLoop.cpp */; };
+		A3CA45E41BCD9D70004C5B45 /* RunLoopCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 2CDED0EE18115C38004DBA70 /* RunLoopCF.cpp */; };
+		A3CA45E51BCD9D70004C5B45 /* RunLoopTimerCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1469419116EAAF6D0024E146 /* RunLoopTimerCF.cpp */; };
+		A3CA45E61BCD9D70004C5B45 /* SchedulePairCF.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1469419816EAB0410024E146 /* SchedulePairCF.cpp */; };
+		A3CA45E71BCD9D70004C5B45 /* StringMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = A5BA15F2182433A900A82E69 /* StringMac.mm */; };
+		A3CA45E81BCD9D70004C5B45 /* SchedulePairMac.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1469419516EAAFF80024E146 /* SchedulePairMac.mm */; };
+		A3CA45E91BCD9D70004C5B45 /* SHA1.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47308151A825B004123FF /* SHA1.cpp */; };
+		A3CA45EA1BCD9D70004C5B45 /* SixCharacterHash.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A748744F17A0BDAE00FA04CB /* SixCharacterHash.cpp */; };
+		A3CA45EB1BCD9D70004C5B45 /* StackBounds.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4730E151A825B004123FF /* StackBounds.cpp */; };
+		A3CA45EC1BCD9D70004C5B45 /* StackStats.cpp in Sources */ = {isa = PBXBuildFile; fileRef = FEDACD3B1630F83F00C69634 /* StackStats.cpp */; };
+		A3CA45ED1BCD9D70004C5B45 /* StringBuilder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47324151A825B004123FF /* StringBuilder.cpp */; };
+		A3CA45EE1BCD9D70004C5B45 /* StringImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47328151A825B004123FF /* StringImpl.cpp */; };
+		A3CA45EF1BCD9D70004C5B45 /* StringPrintStream.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 0FDDBFA51666DFA300C55FEF /* StringPrintStream.cpp */; };
+		A3CA45F01BCD9D70004C5B45 /* StringStatics.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4732B151A825B004123FF /* StringStatics.cpp */; };
+		A3CA45F11BCD9D70004C5B45 /* strtod.cc in Sources */ = {isa = PBXBuildFile; fileRef = A8A47294151A825A004123FF /* strtod.cc */; };
+		A3CA45F21BCD9D70004C5B45 /* TCSystemAlloc.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47318151A825B004123FF /* TCSystemAlloc.cpp */; };
+		A3CA45F31BCD9D70004C5B45 /* ThreadIdentifierDataPthreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47330151A825B004123FF /* ThreadIdentifierDataPthreads.cpp */; };
+		A3CA45F41BCD9D70004C5B45 /* Threading.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47332151A825B004123FF /* Threading.cpp */; };
+		A3CA45F51BCD9D70004C5B45 /* ThreadingPthreads.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47336151A825B004123FF /* ThreadingPthreads.cpp */; };
+		A3CA45F61BCD9D70004C5B45 /* UTF8.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A47357151A825B004123FF /* UTF8.cpp */; };
+		A3CA45F71BCD9D70004C5B45 /* WebCoreThread.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1FA47C88152502DA00568D1B /* WebCoreThread.cpp */; };
+		A3CA45F81BCD9D70004C5B45 /* WTFString.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4732D151A825B004123FF /* WTFString.cpp */; };
+		A3CA45F91BCD9D70004C5B45 /* WTFThreadData.cpp in Sources */ = {isa = PBXBuildFile; fileRef = A8A4737A151A825B004123FF /* WTFThreadData.cpp */; };
+		A3CA45FC1BCD9D70004C5B45 /* ASCIICType.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4725A151A825A004123FF /* ASCIICType.h */; };
+		A3CA45FD1BCD9D70004C5B45 /* ASCIIFastPath.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4731C151A825B004123FF /* ASCIIFastPath.h */; };
+		A3CA45FE1BCD9D70004C5B45 /* Assertions.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4725C151A825A004123FF /* Assertions.h */; };
+		A3CA45FF1BCD9D70004C5B45 /* Atomics.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4725D151A825A004123FF /* Atomics.h */; };
+		A3CA46001BCD9D70004C5B45 /* AtomicString.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4731E151A825B004123FF /* AtomicString.h */; };
+		A3CA46011BCD9D70004C5B45 /* AtomicStringHash.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4731F151A825B004123FF /* AtomicStringHash.h */; };
+		A3CA46021BCD9D70004C5B45 /* AtomicStringImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47320151A825B004123FF /* AtomicStringImpl.h */; };
+		A3CA46031BCD9D70004C5B45 /* AtomicStringTable.h in Headers */ = {isa = PBXBuildFile; fileRef = 9BD8F40A176C2AD80002D865 /* AtomicStringTable.h */; };
+		A3CA46041BCD9D70004C5B45 /* AutodrainedPool.h in Headers */ = {isa = PBXBuildFile; fileRef = 1469419A16EAB10A0024E146 /* AutodrainedPool.h */; };
+		A3CA46051BCD9D70004C5B45 /* AVLTree.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4725E151A825A004123FF /* AVLTree.h */; };
+		A3CA46061BCD9D70004C5B45 /* Base64.h in Headers */ = {isa = PBXBuildFile; fileRef = 8134013715B092FD001FF0B8 /* Base64.h */; };
+		A3CA46071BCD9D70004C5B45 /* bignum-dtoa.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47283151A825A004123FF /* bignum-dtoa.h */; };
+		A3CA46081BCD9D70004C5B45 /* bignum.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47285151A825A004123FF /* bignum.h */; };
+		A3CA46091BCD9D70004C5B45 /* BinarySemaphore.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4733B151A825B004123FF /* BinarySemaphore.h */; };
+		A3CA460A1BCD9D70004C5B45 /* Bitmap.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4725F151A825A004123FF /* Bitmap.h */; };
+		A3CA460B1BCD9D70004C5B45 /* BitVector.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47261151A825A004123FF /* BitVector.h */; };
+		A3CA460C1BCD9D70004C5B45 /* BlockStack.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47264151A825A004123FF /* BlockStack.h */; };
+		A3CA460D1BCD9D70004C5B45 /* BloomFilter.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47265151A825A004123FF /* BloomFilter.h */; };
+		A3CA460E1BCD9D70004C5B45 /* BoundsCheckedPointer.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47266151A825A004123FF /* BoundsCheckedPointer.h */; };
+		A3CA460F1BCD9D70004C5B45 /* BumpPointerAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47267151A825A004123FF /* BumpPointerAllocator.h */; };
+		A3CA46101BCD9D70004C5B45 /* ByteOrder.h in Headers */ = {isa = PBXBuildFile; fileRef = EB95E1EF161A72410089A2F5 /* ByteOrder.h */; };
+		A3CA46111BCD9D70004C5B45 /* cached-powers.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47287151A825A004123FF /* cached-powers.h */; };
+		A3CA46121BCD9D70004C5B45 /* CharacterNames.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47349151A825B004123FF /* CharacterNames.h */; };
+		A3CA46131BCD9D70004C5B45 /* CheckedArithmetic.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4726A151A825A004123FF /* CheckedArithmetic.h */; };
+		A3CA46141BCD9D70004C5B45 /* CheckedBoolean.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4726B151A825A004123FF /* CheckedBoolean.h */; };
+		A3CA46151BCD9D70004C5B45 /* Collator.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4734A151A825B004123FF /* Collator.h */; };
+		A3CA46161BCD9D70004C5B45 /* CommaPrinter.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4EDE51696149600F65041 /* CommaPrinter.h */; };
+		A3CA46171BCD9D70004C5B45 /* CompilationThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8F2B90172E00F0007DBDA5 /* CompilationThread.h */; };
+		A3CA46181BCD9D70004C5B45 /* Compiler.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47270151A825A004123FF /* Compiler.h */; };
+		A3CA46191BCD9D70004C5B45 /* Compression.h in Headers */ = {isa = PBXBuildFile; fileRef = A7E643C517C5423B003BB16B /* Compression.h */; };
+		A3CA461A1BCD9D70004C5B45 /* config.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4748B151A8264004123FF /* config.h */; };
+		A3CA461B1BCD9D70004C5B45 /* ConversionMode.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F8F2B9B172F2594007DBDA5 /* ConversionMode.h */; };
+		A3CA461C1BCD9D70004C5B45 /* CryptographicallyRandomNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47274151A825A004123FF /* CryptographicallyRandomNumber.h */; };
+		A3CA461D1BCD9D70004C5B45 /* CString.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47322151A825B004123FF /* CString.h */; };
+		A3CA461E1BCD9D70004C5B45 /* CurrentTime.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47276151A825A004123FF /* CurrentTime.h */; };
+		A3CA461F1BCD9D70004C5B45 /* DataLog.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47278151A825A004123FF /* DataLog.h */; };
+		A3CA46201BCD9D70004C5B45 /* DateMath.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4727A151A825A004123FF /* DateMath.h */; };
+		A3CA46211BCD9D70004C5B45 /* DecimalNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4727C151A825A004123FF /* DecimalNumber.h */; };
+		A3CA46221BCD9D70004C5B45 /* Decoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4727D151A825A004123FF /* Decoder.h */; };
+		A3CA46231BCD9D70004C5B45 /* DeferrableRefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66A417B6B4F700A7AE3F /* DeferrableRefCounted.h */; };
+		A3CA46241BCD9D70004C5B45 /* Deque.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4727E151A825A004123FF /* Deque.h */; };
+		A3CA46251BCD9D70004C5B45 /* DisallowCType.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4727F151A825A004123FF /* DisallowCType.h */; };
+		A3CA46261BCD9D70004C5B45 /* diy-fp.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4728A151A825A004123FF /* diy-fp.h */; };
+		A3CA46271BCD9D70004C5B45 /* double-conversion.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4728C151A825A004123FF /* double-conversion.h */; };
+		A3CA46281BCD9D70004C5B45 /* double.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4728D151A825A004123FF /* double.h */; };
+		A3CA46291BCD9D70004C5B45 /* DoublyLinkedList.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47280151A825A004123FF /* DoublyLinkedList.h */; };
+		A3CA462A1BCD9D70004C5B45 /* dtoa.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47298151A825A004123FF /* dtoa.h */; };
+		A3CA462B1BCD9D70004C5B45 /* DynamicAnnotations.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4729A151A825A004123FF /* DynamicAnnotations.h */; };
+		A3CA462C1BCD9D70004C5B45 /* Encoder.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4729E151A825A004123FF /* Encoder.h */; };
+		A3CA462D1BCD9D70004C5B45 /* ExportMacros.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4729F151A825A004123FF /* ExportMacros.h */; };
+		A3CA462E1BCD9D70004C5B45 /* fast-dtoa.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4728F151A825A004123FF /* fast-dtoa.h */; };
+		A3CA462F1BCD9D70004C5B45 /* FastBitVector.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FD81AC4154FB22E00983E72 /* FastBitVector.h */; settings = {ATTRIBUTES = (); }; };
+		A3CA46301BCD9D70004C5B45 /* FastMalloc.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472A2151A825A004123FF /* FastMalloc.h */; };
+		A3CA46311BCD9D70004C5B45 /* FeatureDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = B38FD7BC168953E80065C969 /* FeatureDefines.h */; };
+		A3CA46321BCD9D70004C5B45 /* FilePrintStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9D335C165DBA73005AD387 /* FilePrintStream.h */; };
+		A3CA46331BCD9D70004C5B45 /* fixed-dtoa.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47291151A825A004123FF /* fixed-dtoa.h */; };
+		A3CA46341BCD9D70004C5B45 /* FlipBytes.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2B66A517B6B4F700A7AE3F /* FlipBytes.h */; };
+		A3CA46351BCD9D70004C5B45 /* Forward.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472A6151A825A004123FF /* Forward.h */; };
+		A3CA46361BCD9D70004C5B45 /* Functional.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472A7151A825A004123FF /* Functional.h */; };
+		A3CA46371BCD9D70004C5B45 /* FunctionDispatcher.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A1D8B9B173186CE00141DA4 /* FunctionDispatcher.h */; };
+		A3CA46381BCD9D70004C5B45 /* GetPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472A8151A825A004123FF /* GetPtr.h */; };
+		A3CA46391BCD9D70004C5B45 /* GregorianDateTime.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C05385315BC819000F21B96 /* GregorianDateTime.h */; };
+		A3CA463A1BCD9D70004C5B45 /* HashCountedSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472B3151A825A004123FF /* HashCountedSet.h */; };
+		A3CA463B1BCD9D70004C5B45 /* HashFunctions.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472B4151A825A004123FF /* HashFunctions.h */; };
+		A3CA463C1BCD9D70004C5B45 /* HashIterators.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472B5151A825A004123FF /* HashIterators.h */; };
+		A3CA463D1BCD9D70004C5B45 /* HashMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472B6151A825A004123FF /* HashMap.h */; };
+		A3CA463E1BCD9D70004C5B45 /* MallocPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A233C7C17DAA6E300A93ACF /* MallocPtr.h */; };
+		A3CA463F1BCD9D70004C5B45 /* HashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472B7151A825A004123FF /* HashSet.h */; };
+		A3CA46401BCD9D70004C5B45 /* HashTable.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472B9151A825A004123FF /* HashTable.h */; };
+		A3CA46411BCD9D70004C5B45 /* HashTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472BA151A825A004123FF /* HashTraits.h */; };
+		A3CA46421BCD9D70004C5B45 /* HexNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472BB151A825A004123FF /* HexNumber.h */; };
+		A3CA46431BCD9D70004C5B45 /* InlineASM.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472BC151A825A004123FF /* InlineASM.h */; };
+		A3CA46441BCD9D70004C5B45 /* Ref.h in Headers */ = {isa = PBXBuildFile; fileRef = 26299B6D17A9E5B800ADEBE5 /* Ref.h */; };
+		A3CA46451BCD9D70004C5B45 /* Insertion.h in Headers */ = {isa = PBXBuildFile; fileRef = A70DA0821799F04D00529A9B /* Insertion.h */; };
+		A3CA46461BCD9D70004C5B45 /* IntegerToStringConversion.h in Headers */ = {isa = PBXBuildFile; fileRef = 26147B0815DDCCDC00DDB907 /* IntegerToStringConversion.h */; };
+		A3CA46471BCD9D70004C5B45 /* ListDump.h in Headers */ = {isa = PBXBuildFile; fileRef = A70DA0831799F04D00529A9B /* ListDump.h */; };
+		A3CA46481BCD9D70004C5B45 /* ListHashSet.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472C1151A825A004123FF /* ListHashSet.h */; };
+		A3CA46491BCD9D70004C5B45 /* Locker.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472C3151A825A004123FF /* Locker.h */; };
+		A3CA464A1BCD9D70004C5B45 /* MainThread.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472C7151A825B004123FF /* MainThread.h */; };
+		A3CA464B1BCD9D70004C5B45 /* MathExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472C9151A825B004123FF /* MathExtras.h */; };
+		A3CA464C1BCD9D70004C5B45 /* PassRef.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B1AA7F180E5AF3004A2F05 /* PassRef.h */; };
+		A3CA464D1BCD9D70004C5B45 /* MD5.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472CB151A825B004123FF /* MD5.h */; };
+		A3CA464E1BCD9D70004C5B45 /* MediaTime.h in Headers */ = {isa = PBXBuildFile; fileRef = CD5497AB15857D0300B5BC30 /* MediaTime.h */; };
+		A3CA464F1BCD9D70004C5B45 /* MessageQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472CC151A825B004123FF /* MessageQueue.h */; };
+		A3CA46501BCD9D70004C5B45 /* MetaAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472CE151A825B004123FF /* MetaAllocator.h */; };
+		A3CA46511BCD9D70004C5B45 /* MetaAllocatorHandle.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472CF151A825B004123FF /* MetaAllocatorHandle.h */; };
+		A3CA46521BCD9D70004C5B45 /* NoLock.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F0D85B317234CB100338210 /* NoLock.h */; };
+		A3CA46531BCD9D70004C5B45 /* Noncopyable.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472D0151A825B004123FF /* Noncopyable.h */; };
+		A3CA46541BCD9D70004C5B45 /* NumberOfCores.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472D6151A825B004123FF /* NumberOfCores.h */; };
+		A3CA46551BCD9D70004C5B45 /* ObjcRuntimeExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = 7E29C33D15FFD79B00516D61 /* ObjcRuntimeExtras.h */; };
+		A3CA46561BCD9D70004C5B45 /* OSAllocator.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472D7151A825B004123FF /* OSAllocator.h */; };
+		A3CA46571BCD9D70004C5B45 /* OSRandomSource.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472DB151A825B004123FF /* OSRandomSource.h */; };
+		A3CA46581BCD9D70004C5B45 /* OwnPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472DD151A825B004123FF /* OwnPtr.h */; };
+		A3CA46591BCD9D70004C5B45 /* OwnPtrCommon.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472DE151A825B004123FF /* OwnPtrCommon.h */; };
+		A3CA465A1BCD9D70004C5B45 /* BagToHashMap.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB14E1A1810E1DA009B6B4D /* BagToHashMap.h */; };
+		A3CA465B1BCD9D70004C5B45 /* PackedIntVector.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472DF151A825B004123FF /* PackedIntVector.h */; };
+		A3CA465C1BCD9D70004C5B45 /* PageAllocation.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472E0151A825B004123FF /* PageAllocation.h */; };
+		A3CA465D1BCD9D70004C5B45 /* PageAllocationAligned.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472E2151A825B004123FF /* PageAllocationAligned.h */; };
+		A3CA465E1BCD9D70004C5B45 /* PageBlock.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472E4151A825B004123FF /* PageBlock.h */; };
+		A3CA465F1BCD9D70004C5B45 /* PageReservation.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472E5151A825B004123FF /* PageReservation.h */; };
+		A3CA46601BCD9D70004C5B45 /* ParallelJobs.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472E6151A825B004123FF /* ParallelJobs.h */; };
+		A3CA46611BCD9D70004C5B45 /* ParallelJobsLibdispatch.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472E9151A825B004123FF /* ParallelJobsLibdispatch.h */; };
+		A3CA46621BCD9D70004C5B45 /* PassOwnPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472EC151A825B004123FF /* PassOwnPtr.h */; };
+		A3CA46631BCD9D70004C5B45 /* PassRefPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472ED151A825B004123FF /* PassRefPtr.h */; };
+		A3CA46641BCD9D70004C5B45 /* Platform.h in Headers */ = {isa = PBXBuildFile; fileRef = A876DBD7151816E500DADB95 /* Platform.h */; };
+		A3CA46651BCD9D70004C5B45 /* PossiblyNull.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472F3151A825B004123FF /* PossiblyNull.h */; };
+		A3CA46661BCD9D70004C5B45 /* Bag.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FB14E18180FA218009B6B4D /* Bag.h */; };
+		A3CA46671BCD9D70004C5B45 /* PrintStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F9D335E165DBA73005AD387 /* PrintStream.h */; };
+		A3CA46681BCD9D70004C5B45 /* ProcessID.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FC4488216FE9FE100844BE9 /* ProcessID.h */; };
+		A3CA46691BCD9D70004C5B45 /* RAMSize.h in Headers */ = {isa = PBXBuildFile; fileRef = 143F611E1565F0F900DB514A /* RAMSize.h */; settings = {ATTRIBUTES = (); }; };
+		A3CA466A1BCD9D70004C5B45 /* RandomNumber.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472FC151A825B004123FF /* RandomNumber.h */; };
+		A3CA466B1BCD9D70004C5B45 /* RandomNumberSeed.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472FD151A825B004123FF /* RandomNumberSeed.h */; };
+		A3CA466C1BCD9D70004C5B45 /* RawPointer.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F87105916643F190090B0AD /* RawPointer.h */; };
+		A3CA466D1BCD9D70004C5B45 /* RedBlackTree.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472FE151A825B004123FF /* RedBlackTree.h */; };
+		A3CA466E1BCD9D70004C5B45 /* RefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A472FF151A825B004123FF /* RefCounted.h */; };
+		A3CA466F1BCD9D70004C5B45 /* RefCountedArray.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47300151A825B004123FF /* RefCountedArray.h */; };
+		A3CA46701BCD9D70004C5B45 /* RefCountedLeakCounter.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47302151A825B004123FF /* RefCountedLeakCounter.h */; };
+		A3CA46711BCD9D70004C5B45 /* RefPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47303151A825B004123FF /* RefPtr.h */; };
+		A3CA46721BCD9D70004C5B45 /* RefPtrHashMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47304151A825B004123FF /* RefPtrHashMap.h */; };
+		A3CA46731BCD9D70004C5B45 /* RetainPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47305151A825B004123FF /* RetainPtr.h */; };
+		A3CA46741BCD9D70004C5B45 /* RunLoop.h in Headers */ = {isa = PBXBuildFile; fileRef = 2CDED0F218115C85004DBA70 /* RunLoop.h */; };
+		A3CA46751BCD9D70004C5B45 /* RunLoopTimer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1469419016EAAF6D0024E146 /* RunLoopTimer.h */; settings = {ATTRIBUTES = (); }; };
+		A3CA46761BCD9D70004C5B45 /* SaturatedArithmetic.h in Headers */ = {isa = PBXBuildFile; fileRef = 14F3B0F615E45E4600210069 /* SaturatedArithmetic.h */; settings = {ATTRIBUTES = (); }; };
+		A3CA46771BCD9D70004C5B45 /* SchedulePair.h in Headers */ = {isa = PBXBuildFile; fileRef = 1469419416EAAFF80024E146 /* SchedulePair.h */; };
+		A3CA46781BCD9D70004C5B45 /* ScriptCodesFromICU.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47354151A825B004123FF /* ScriptCodesFromICU.h */; };
+		A3CA46791BCD9D70004C5B45 /* SegmentedVector.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47306151A825B004123FF /* SegmentedVector.h */; };
+		A3CA467A1BCD9D70004C5B45 /* SentinelLinkedList.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47307151A825B004123FF /* SentinelLinkedList.h */; };
+		A3CA467B1BCD9D70004C5B45 /* SHA1.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47309151A825B004123FF /* SHA1.h */; };
+		A3CA467C1BCD9D70004C5B45 /* SimpleStats.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730A151A825B004123FF /* SimpleStats.h */; };
+		A3CA467D1BCD9D70004C5B45 /* SinglyLinkedList.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730B151A825B004123FF /* SinglyLinkedList.h */; };
+		A3CA467E1BCD9D70004C5B45 /* SixCharacterHash.h in Headers */ = {isa = PBXBuildFile; fileRef = A748745017A0BDAE00FA04CB /* SixCharacterHash.h */; };
+		A3CA467F1BCD9D70004C5B45 /* Spectrum.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730D151A825B004123FF /* Spectrum.h */; };
+		A3CA46801BCD9D70004C5B45 /* StackBounds.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4730F151A825B004123FF /* StackBounds.h */; };
+		A3CA46811BCD9D70004C5B45 /* StackStats.h in Headers */ = {isa = PBXBuildFile; fileRef = FEDACD3C1630F83F00C69634 /* StackStats.h */; };
+		A3CA46821BCD9D70004C5B45 /* StaticConstructors.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47310151A825B004123FF /* StaticConstructors.h */; };
+		A3CA46831BCD9D70004C5B45 /* StdLibExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47311151A825B004123FF /* StdLibExtras.h */; };
+		A3CA46841BCD9D70004C5B45 /* StreamBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A6BB768162F300500DD16DB /* StreamBuffer.h */; };
+		A3CA46851BCD9D70004C5B45 /* StringBuffer.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47323151A825B004123FF /* StringBuffer.h */; };
+		A3CA46861BCD9D70004C5B45 /* StringBuilder.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47325151A825B004123FF /* StringBuilder.h */; };
+		A3CA46871BCD9D70004C5B45 /* StringConcatenate.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47326151A825B004123FF /* StringConcatenate.h */; };
+		A3CA46881BCD9D70004C5B45 /* StringExtras.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47313151A825B004123FF /* StringExtras.h */; };
+		A3CA46891BCD9D70004C5B45 /* StringHash.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47327151A825B004123FF /* StringHash.h */; };
+		A3CA468A1BCD9D70004C5B45 /* StringHashDumpContext.h in Headers */ = {isa = PBXBuildFile; fileRef = A748745117A0BDAE00FA04CB /* StringHashDumpContext.h */; };
+		A3CA468B1BCD9D70004C5B45 /* StringHasher.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47314151A825B004123FF /* StringHasher.h */; };
+		A3CA468C1BCD9D70004C5B45 /* StringImpl.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47329151A825B004123FF /* StringImpl.h */; };
+		A3CA468D1BCD9D70004C5B45 /* StringOperators.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4732A151A825B004123FF /* StringOperators.h */; };
+		A3CA468E1BCD9D70004C5B45 /* StringPrintStream.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FDDBFA61666DFA300C55FEF /* StringPrintStream.h */; };
+		A3CA468F1BCD9D70004C5B45 /* strtod.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47295151A825A004123FF /* strtod.h */; };
+		A3CA46901BCD9D70004C5B45 /* TCPackedCache.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47315151A825B004123FF /* TCPackedCache.h */; };
+		A3CA46911BCD9D70004C5B45 /* TCPageMap.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47316151A825B004123FF /* TCPageMap.h */; };
+		A3CA46921BCD9D70004C5B45 /* TCSpinLock.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47317151A825B004123FF /* TCSpinLock.h */; };
+		A3CA46931BCD9D70004C5B45 /* TCSystemAlloc.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47319151A825B004123FF /* TCSystemAlloc.h */; };
+		A3CA46941BCD9D70004C5B45 /* StringView.h in Headers */ = {isa = PBXBuildFile; fileRef = 1A6EB1DF187D0BD30030126F /* StringView.h */; };
+		A3CA46951BCD9D70004C5B45 /* TemporaryChange.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4731A151A825B004123FF /* TemporaryChange.h */; };
+		A3CA46961BCD9D70004C5B45 /* TextPosition.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4732C151A825B004123FF /* TextPosition.h */; };
+		A3CA46971BCD9D70004C5B45 /* ThreadFunctionInvocation.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4732F151A825B004123FF /* ThreadFunctionInvocation.h */; };
+		A3CA46981BCD9D70004C5B45 /* ThreadIdentifierDataPthreads.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47331151A825B004123FF /* ThreadIdentifierDataPthreads.h */; };
+		A3CA46991BCD9D70004C5B45 /* Threading.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47333151A825B004123FF /* Threading.h */; };
+		A3CA469A1BCD9D70004C5B45 /* ThreadingPrimitives.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47335151A825B004123FF /* ThreadingPrimitives.h */; };
+		A3CA469B1BCD9D70004C5B45 /* ThreadSafeRefCounted.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4733E151A825B004123FF /* ThreadSafeRefCounted.h */; };
+		A3CA469C1BCD9D70004C5B45 /* ThreadSpecific.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4733F151A825B004123FF /* ThreadSpecific.h */; };
+		A3CA469D1BCD9D70004C5B45 /* TriState.h in Headers */ = {isa = PBXBuildFile; fileRef = 149EF16216BBFE0D000A4331 /* TriState.h */; settings = {ATTRIBUTES = (); }; };
+		A3CA469E1BCD9D70004C5B45 /* Unicode.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47355151A825B004123FF /* Unicode.h */; };
+		A3CA469F1BCD9D70004C5B45 /* UnicodeIcu.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47351151A825B004123FF /* UnicodeIcu.h */; };
+		A3CA46A01BCD9D70004C5B45 /* UnicodeMacrosFromICU.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47356151A825B004123FF /* UnicodeMacrosFromICU.h */; };
+		A3CA46A11BCD9D70004C5B45 /* UnionFind.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4735C151A825B004123FF /* UnionFind.h */; };
+		A3CA46A21BCD9D70004C5B45 /* UTF8.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47358151A825B004123FF /* UTF8.h */; };
+		A3CA46A31BCD9D70004C5B45 /* utils.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47296151A825A004123FF /* utils.h */; };
+		A3CA46A41BCD9D70004C5B45 /* ValueCheck.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4736F151A825B004123FF /* ValueCheck.h */; };
+		A3CA46A51BCD9D70004C5B45 /* Vector.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47370151A825B004123FF /* Vector.h */; };
+		A3CA46A61BCD9D70004C5B45 /* VectorTraits.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47371151A825B004123FF /* VectorTraits.h */; };
+		A3CA46A71BCD9D70004C5B45 /* VMTags.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A47372151A825B004123FF /* VMTags.h */; };
+		A3CA46A81BCD9D70004C5B45 /* WeakPtr.h in Headers */ = {isa = PBXBuildFile; fileRef = 974CFC8D16A4F327006D5404 /* WeakPtr.h */; };
+		A3CA46A91BCD9D70004C5B45 /* WebCoreThread.h in Headers */ = {isa = PBXBuildFile; fileRef = 1FA47C89152502DA00568D1B /* WebCoreThread.h */; };
+		A3CA46AA1BCD9D70004C5B45 /* WTFString.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4732E151A825B004123FF /* WTFString.h */; };
+		A3CA46AB1BCD9D70004C5B45 /* WTFThreadData.h in Headers */ = {isa = PBXBuildFile; fileRef = A8A4737B151A825B004123FF /* WTFThreadData.h */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
 		10EAA7041889E93100DEB161 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 5D247B5914689B8600E78B76 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 65AFA16F1630B977003D723C;
+			remoteInfo = "Copy Headers";
+		};
+		A3CA45AF1BCD9D70004C5B45 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 5D247B5914689B8600E78B76 /* Project object */;
 			proxyType = 1;
@@ -343,6 +599,7 @@
 		974CFC8D16A4F327006D5404 /* WeakPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = WeakPtr.h; sourceTree = "<group>"; };
 		9BC70F04176C379D00101DEC /* AtomicStringTable.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AtomicStringTable.cpp; sourceTree = "<group>"; };
 		9BD8F40A176C2AD80002D865 /* AtomicStringTable.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AtomicStringTable.h; sourceTree = "<group>"; };
+		A3CA46B01BCD9D70004C5B45 /* libWTF-tvOS.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libWTF-tvOS.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5BA15F2182433A900A82E69 /* StringMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = StringMac.mm; path = mac/StringMac.mm; sourceTree = "<group>"; };
 		A5BA15F41824348000A82E69 /* StringImplMac.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = StringImplMac.mm; path = mac/StringImplMac.mm; sourceTree = "<group>"; };
 		A5BA15F7182435A600A82E69 /* AtomicStringCF.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = AtomicStringCF.cpp; path = cf/AtomicStringCF.cpp; sourceTree = "<group>"; };
@@ -555,6 +812,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A3CA45FA1BCD9D70004C5B45 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -588,6 +852,7 @@
 			isa = PBXGroup;
 			children = (
 				10EAA8091889E93100DEB161 /* libWTF.a */,
+				A3CA46B01BCD9D70004C5B45 /* libWTF-tvOS.a */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -1124,6 +1389,189 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A3CA45FB1BCD9D70004C5B45 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A3CA45FC1BCD9D70004C5B45 /* ASCIICType.h in Headers */,
+				A3CA45FD1BCD9D70004C5B45 /* ASCIIFastPath.h in Headers */,
+				A3CA45FE1BCD9D70004C5B45 /* Assertions.h in Headers */,
+				A3CA45FF1BCD9D70004C5B45 /* Atomics.h in Headers */,
+				A3CA46001BCD9D70004C5B45 /* AtomicString.h in Headers */,
+				A3CA46011BCD9D70004C5B45 /* AtomicStringHash.h in Headers */,
+				A3CA46021BCD9D70004C5B45 /* AtomicStringImpl.h in Headers */,
+				A3CA46031BCD9D70004C5B45 /* AtomicStringTable.h in Headers */,
+				A3CA46041BCD9D70004C5B45 /* AutodrainedPool.h in Headers */,
+				A3CA46051BCD9D70004C5B45 /* AVLTree.h in Headers */,
+				A3CA46061BCD9D70004C5B45 /* Base64.h in Headers */,
+				A3CA46071BCD9D70004C5B45 /* bignum-dtoa.h in Headers */,
+				A3CA46081BCD9D70004C5B45 /* bignum.h in Headers */,
+				A3CA46091BCD9D70004C5B45 /* BinarySemaphore.h in Headers */,
+				A3CA460A1BCD9D70004C5B45 /* Bitmap.h in Headers */,
+				A3CA460B1BCD9D70004C5B45 /* BitVector.h in Headers */,
+				A3CA460C1BCD9D70004C5B45 /* BlockStack.h in Headers */,
+				A3CA460D1BCD9D70004C5B45 /* BloomFilter.h in Headers */,
+				A3CA460E1BCD9D70004C5B45 /* BoundsCheckedPointer.h in Headers */,
+				A3CA460F1BCD9D70004C5B45 /* BumpPointerAllocator.h in Headers */,
+				A3CA46101BCD9D70004C5B45 /* ByteOrder.h in Headers */,
+				A3CA46111BCD9D70004C5B45 /* cached-powers.h in Headers */,
+				A3CA46121BCD9D70004C5B45 /* CharacterNames.h in Headers */,
+				A3CA46131BCD9D70004C5B45 /* CheckedArithmetic.h in Headers */,
+				A3CA46141BCD9D70004C5B45 /* CheckedBoolean.h in Headers */,
+				A3CA46151BCD9D70004C5B45 /* Collator.h in Headers */,
+				A3CA46161BCD9D70004C5B45 /* CommaPrinter.h in Headers */,
+				A3CA46171BCD9D70004C5B45 /* CompilationThread.h in Headers */,
+				A3CA46181BCD9D70004C5B45 /* Compiler.h in Headers */,
+				A3CA46191BCD9D70004C5B45 /* Compression.h in Headers */,
+				A3CA461A1BCD9D70004C5B45 /* config.h in Headers */,
+				A3CA461B1BCD9D70004C5B45 /* ConversionMode.h in Headers */,
+				A3CA461C1BCD9D70004C5B45 /* CryptographicallyRandomNumber.h in Headers */,
+				A3CA461D1BCD9D70004C5B45 /* CString.h in Headers */,
+				A3CA461E1BCD9D70004C5B45 /* CurrentTime.h in Headers */,
+				A3CA461F1BCD9D70004C5B45 /* DataLog.h in Headers */,
+				A3CA46201BCD9D70004C5B45 /* DateMath.h in Headers */,
+				A3CA46211BCD9D70004C5B45 /* DecimalNumber.h in Headers */,
+				A3CA46221BCD9D70004C5B45 /* Decoder.h in Headers */,
+				A3CA46231BCD9D70004C5B45 /* DeferrableRefCounted.h in Headers */,
+				A3CA46241BCD9D70004C5B45 /* Deque.h in Headers */,
+				A3CA46251BCD9D70004C5B45 /* DisallowCType.h in Headers */,
+				A3CA46261BCD9D70004C5B45 /* diy-fp.h in Headers */,
+				A3CA46271BCD9D70004C5B45 /* double-conversion.h in Headers */,
+				A3CA46281BCD9D70004C5B45 /* double.h in Headers */,
+				A3CA46291BCD9D70004C5B45 /* DoublyLinkedList.h in Headers */,
+				A3CA462A1BCD9D70004C5B45 /* dtoa.h in Headers */,
+				A3CA462B1BCD9D70004C5B45 /* DynamicAnnotations.h in Headers */,
+				A3CA462C1BCD9D70004C5B45 /* Encoder.h in Headers */,
+				A3CA462D1BCD9D70004C5B45 /* ExportMacros.h in Headers */,
+				A3CA462E1BCD9D70004C5B45 /* fast-dtoa.h in Headers */,
+				A3CA462F1BCD9D70004C5B45 /* FastBitVector.h in Headers */,
+				A3CA46301BCD9D70004C5B45 /* FastMalloc.h in Headers */,
+				A3CA46311BCD9D70004C5B45 /* FeatureDefines.h in Headers */,
+				A3CA46321BCD9D70004C5B45 /* FilePrintStream.h in Headers */,
+				A3CA46331BCD9D70004C5B45 /* fixed-dtoa.h in Headers */,
+				A3CA46341BCD9D70004C5B45 /* FlipBytes.h in Headers */,
+				A3CA46351BCD9D70004C5B45 /* Forward.h in Headers */,
+				A3CA46361BCD9D70004C5B45 /* Functional.h in Headers */,
+				A3CA46371BCD9D70004C5B45 /* FunctionDispatcher.h in Headers */,
+				A3CA46381BCD9D70004C5B45 /* GetPtr.h in Headers */,
+				A3CA46391BCD9D70004C5B45 /* GregorianDateTime.h in Headers */,
+				A3CA463A1BCD9D70004C5B45 /* HashCountedSet.h in Headers */,
+				A3CA463B1BCD9D70004C5B45 /* HashFunctions.h in Headers */,
+				A3CA463C1BCD9D70004C5B45 /* HashIterators.h in Headers */,
+				A3CA463D1BCD9D70004C5B45 /* HashMap.h in Headers */,
+				A3CA463E1BCD9D70004C5B45 /* MallocPtr.h in Headers */,
+				A3CA463F1BCD9D70004C5B45 /* HashSet.h in Headers */,
+				A3CA46401BCD9D70004C5B45 /* HashTable.h in Headers */,
+				A3CA46411BCD9D70004C5B45 /* HashTraits.h in Headers */,
+				A3CA46421BCD9D70004C5B45 /* HexNumber.h in Headers */,
+				A3CA46431BCD9D70004C5B45 /* InlineASM.h in Headers */,
+				A3CA46441BCD9D70004C5B45 /* Ref.h in Headers */,
+				A3CA46451BCD9D70004C5B45 /* Insertion.h in Headers */,
+				A3CA46461BCD9D70004C5B45 /* IntegerToStringConversion.h in Headers */,
+				A3CA46471BCD9D70004C5B45 /* ListDump.h in Headers */,
+				A3CA46481BCD9D70004C5B45 /* ListHashSet.h in Headers */,
+				A3CA46491BCD9D70004C5B45 /* Locker.h in Headers */,
+				A3CA464A1BCD9D70004C5B45 /* MainThread.h in Headers */,
+				A3CA464B1BCD9D70004C5B45 /* MathExtras.h in Headers */,
+				A3CA464C1BCD9D70004C5B45 /* PassRef.h in Headers */,
+				A3CA464D1BCD9D70004C5B45 /* MD5.h in Headers */,
+				A3CA464E1BCD9D70004C5B45 /* MediaTime.h in Headers */,
+				A3CA464F1BCD9D70004C5B45 /* MessageQueue.h in Headers */,
+				A3CA46501BCD9D70004C5B45 /* MetaAllocator.h in Headers */,
+				A3CA46511BCD9D70004C5B45 /* MetaAllocatorHandle.h in Headers */,
+				A3CA46521BCD9D70004C5B45 /* NoLock.h in Headers */,
+				A3CA46531BCD9D70004C5B45 /* Noncopyable.h in Headers */,
+				A3CA46541BCD9D70004C5B45 /* NumberOfCores.h in Headers */,
+				A3CA46551BCD9D70004C5B45 /* ObjcRuntimeExtras.h in Headers */,
+				A3CA46561BCD9D70004C5B45 /* OSAllocator.h in Headers */,
+				A3CA46571BCD9D70004C5B45 /* OSRandomSource.h in Headers */,
+				A3CA46581BCD9D70004C5B45 /* OwnPtr.h in Headers */,
+				A3CA46591BCD9D70004C5B45 /* OwnPtrCommon.h in Headers */,
+				A3CA465A1BCD9D70004C5B45 /* BagToHashMap.h in Headers */,
+				A3CA465B1BCD9D70004C5B45 /* PackedIntVector.h in Headers */,
+				A3CA465C1BCD9D70004C5B45 /* PageAllocation.h in Headers */,
+				A3CA465D1BCD9D70004C5B45 /* PageAllocationAligned.h in Headers */,
+				A3CA465E1BCD9D70004C5B45 /* PageBlock.h in Headers */,
+				A3CA465F1BCD9D70004C5B45 /* PageReservation.h in Headers */,
+				A3CA46601BCD9D70004C5B45 /* ParallelJobs.h in Headers */,
+				A3CA46611BCD9D70004C5B45 /* ParallelJobsLibdispatch.h in Headers */,
+				A3CA46621BCD9D70004C5B45 /* PassOwnPtr.h in Headers */,
+				A3CA46631BCD9D70004C5B45 /* PassRefPtr.h in Headers */,
+				A3CA46641BCD9D70004C5B45 /* Platform.h in Headers */,
+				A3CA46651BCD9D70004C5B45 /* PossiblyNull.h in Headers */,
+				A3CA46661BCD9D70004C5B45 /* Bag.h in Headers */,
+				A3CA46671BCD9D70004C5B45 /* PrintStream.h in Headers */,
+				A3CA46681BCD9D70004C5B45 /* ProcessID.h in Headers */,
+				A3CA46691BCD9D70004C5B45 /* RAMSize.h in Headers */,
+				A3CA466A1BCD9D70004C5B45 /* RandomNumber.h in Headers */,
+				A3CA466B1BCD9D70004C5B45 /* RandomNumberSeed.h in Headers */,
+				A3CA466C1BCD9D70004C5B45 /* RawPointer.h in Headers */,
+				A3CA466D1BCD9D70004C5B45 /* RedBlackTree.h in Headers */,
+				A3CA466E1BCD9D70004C5B45 /* RefCounted.h in Headers */,
+				A3CA466F1BCD9D70004C5B45 /* RefCountedArray.h in Headers */,
+				A3CA46701BCD9D70004C5B45 /* RefCountedLeakCounter.h in Headers */,
+				A3CA46711BCD9D70004C5B45 /* RefPtr.h in Headers */,
+				A3CA46721BCD9D70004C5B45 /* RefPtrHashMap.h in Headers */,
+				A3CA46731BCD9D70004C5B45 /* RetainPtr.h in Headers */,
+				A3CA46741BCD9D70004C5B45 /* RunLoop.h in Headers */,
+				A3CA46751BCD9D70004C5B45 /* RunLoopTimer.h in Headers */,
+				A3CA46761BCD9D70004C5B45 /* SaturatedArithmetic.h in Headers */,
+				A3CA46771BCD9D70004C5B45 /* SchedulePair.h in Headers */,
+				A3CA46781BCD9D70004C5B45 /* ScriptCodesFromICU.h in Headers */,
+				A3CA46791BCD9D70004C5B45 /* SegmentedVector.h in Headers */,
+				A3CA467A1BCD9D70004C5B45 /* SentinelLinkedList.h in Headers */,
+				A3CA467B1BCD9D70004C5B45 /* SHA1.h in Headers */,
+				A3CA467C1BCD9D70004C5B45 /* SimpleStats.h in Headers */,
+				A3CA467D1BCD9D70004C5B45 /* SinglyLinkedList.h in Headers */,
+				A3CA467E1BCD9D70004C5B45 /* SixCharacterHash.h in Headers */,
+				A3CA467F1BCD9D70004C5B45 /* Spectrum.h in Headers */,
+				A3CA46801BCD9D70004C5B45 /* StackBounds.h in Headers */,
+				A3CA46811BCD9D70004C5B45 /* StackStats.h in Headers */,
+				A3CA46821BCD9D70004C5B45 /* StaticConstructors.h in Headers */,
+				A3CA46831BCD9D70004C5B45 /* StdLibExtras.h in Headers */,
+				A3CA46841BCD9D70004C5B45 /* StreamBuffer.h in Headers */,
+				A3CA46851BCD9D70004C5B45 /* StringBuffer.h in Headers */,
+				A3CA46861BCD9D70004C5B45 /* StringBuilder.h in Headers */,
+				A3CA46871BCD9D70004C5B45 /* StringConcatenate.h in Headers */,
+				A3CA46881BCD9D70004C5B45 /* StringExtras.h in Headers */,
+				A3CA46891BCD9D70004C5B45 /* StringHash.h in Headers */,
+				A3CA468A1BCD9D70004C5B45 /* StringHashDumpContext.h in Headers */,
+				A3CA468B1BCD9D70004C5B45 /* StringHasher.h in Headers */,
+				A3CA468C1BCD9D70004C5B45 /* StringImpl.h in Headers */,
+				A3CA468D1BCD9D70004C5B45 /* StringOperators.h in Headers */,
+				A3CA468E1BCD9D70004C5B45 /* StringPrintStream.h in Headers */,
+				A3CA468F1BCD9D70004C5B45 /* strtod.h in Headers */,
+				A3CA46901BCD9D70004C5B45 /* TCPackedCache.h in Headers */,
+				A3CA46911BCD9D70004C5B45 /* TCPageMap.h in Headers */,
+				A3CA46921BCD9D70004C5B45 /* TCSpinLock.h in Headers */,
+				A3CA46931BCD9D70004C5B45 /* TCSystemAlloc.h in Headers */,
+				A3CA46941BCD9D70004C5B45 /* StringView.h in Headers */,
+				A3CA46951BCD9D70004C5B45 /* TemporaryChange.h in Headers */,
+				A3CA46961BCD9D70004C5B45 /* TextPosition.h in Headers */,
+				A3CA46971BCD9D70004C5B45 /* ThreadFunctionInvocation.h in Headers */,
+				A3CA46981BCD9D70004C5B45 /* ThreadIdentifierDataPthreads.h in Headers */,
+				A3CA46991BCD9D70004C5B45 /* Threading.h in Headers */,
+				A3CA469A1BCD9D70004C5B45 /* ThreadingPrimitives.h in Headers */,
+				A3CA469B1BCD9D70004C5B45 /* ThreadSafeRefCounted.h in Headers */,
+				A3CA469C1BCD9D70004C5B45 /* ThreadSpecific.h in Headers */,
+				A3CA469D1BCD9D70004C5B45 /* TriState.h in Headers */,
+				A3CA469E1BCD9D70004C5B45 /* Unicode.h in Headers */,
+				A3CA469F1BCD9D70004C5B45 /* UnicodeIcu.h in Headers */,
+				A3CA46A01BCD9D70004C5B45 /* UnicodeMacrosFromICU.h in Headers */,
+				A3CA46A11BCD9D70004C5B45 /* UnionFind.h in Headers */,
+				A3CA46A21BCD9D70004C5B45 /* UTF8.h in Headers */,
+				A3CA46A31BCD9D70004C5B45 /* utils.h in Headers */,
+				A3CA46A41BCD9D70004C5B45 /* ValueCheck.h in Headers */,
+				A3CA46A51BCD9D70004C5B45 /* Vector.h in Headers */,
+				A3CA46A61BCD9D70004C5B45 /* VectorTraits.h in Headers */,
+				A3CA46A71BCD9D70004C5B45 /* VMTags.h in Headers */,
+				A3CA46A81BCD9D70004C5B45 /* WeakPtr.h in Headers */,
+				A3CA46A91BCD9D70004C5B45 /* WebCoreThread.h in Headers */,
+				A3CA46AA1BCD9D70004C5B45 /* WTFString.h in Headers */,
+				A3CA46AB1BCD9D70004C5B45 /* WTFThreadData.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
@@ -1143,6 +1591,24 @@
 			name = "WTF iOS";
 			productName = WTF;
 			productReference = 10EAA8091889E93100DEB161 /* libWTF.a */;
+			productType = "com.apple.product-type.library.static";
+		};
+		A3CA45AD1BCD9D70004C5B45 /* WTF tvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = A3CA46AC1BCD9D70004C5B45 /* Build configuration list for PBXNativeTarget "WTF tvOS" */;
+			buildPhases = (
+				A3CA45B01BCD9D70004C5B45 /* Sources */,
+				A3CA45FA1BCD9D70004C5B45 /* Frameworks */,
+				A3CA45FB1BCD9D70004C5B45 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				A3CA45AE1BCD9D70004C5B45 /* PBXTargetDependency */,
+			);
+			name = "WTF tvOS";
+			productName = WTF;
+			productReference = A3CA46B01BCD9D70004C5B45 /* libWTF-tvOS.a */;
 			productType = "com.apple.product-type.library.static";
 		};
 /* End PBXNativeTarget section */
@@ -1167,6 +1633,7 @@
 			targets = (
 				65AFA16F1630B977003D723C /* Copy WTF Headers */,
 				10EAA7021889E93100DEB161 /* WTF iOS */,
+				A3CA45AD1BCD9D70004C5B45 /* WTF tvOS */,
 			);
 		};
 /* End PBXProject section */
@@ -1269,6 +1736,86 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		A3CA45B01BCD9D70004C5B45 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				A3CA45B11BCD9D70004C5B45 /* Assertions.cpp in Sources */,
+				A3CA45B21BCD9D70004C5B45 /* AtomicString.cpp in Sources */,
+				A3CA45B31BCD9D70004C5B45 /* AtomicStringTable.cpp in Sources */,
+				A3CA45B41BCD9D70004C5B45 /* StringCF.cpp in Sources */,
+				A3CA45B51BCD9D70004C5B45 /* AutodrainedPoolMac.mm in Sources */,
+				A3CA45B61BCD9D70004C5B45 /* Base64.cpp in Sources */,
+				A3CA45B71BCD9D70004C5B45 /* bignum-dtoa.cc in Sources */,
+				A3CA45B81BCD9D70004C5B45 /* bignum.cc in Sources */,
+				A3CA45B91BCD9D70004C5B45 /* BinarySemaphore.cpp in Sources */,
+				A3CA45BA1BCD9D70004C5B45 /* BitVector.cpp in Sources */,
+				A3CA45BB1BCD9D70004C5B45 /* cached-powers.cc in Sources */,
+				A3CA45BC1BCD9D70004C5B45 /* CollatorDefault.cpp in Sources */,
+				A3CA45BD1BCD9D70004C5B45 /* CollatorICU.cpp in Sources */,
+				A3CA45BE1BCD9D70004C5B45 /* CompilationThread.cpp in Sources */,
+				A3CA45BF1BCD9D70004C5B45 /* Compression.cpp in Sources */,
+				A3CA45C01BCD9D70004C5B45 /* CryptographicallyRandomNumber.cpp in Sources */,
+				A3CA45C11BCD9D70004C5B45 /* CString.cpp in Sources */,
+				A3CA45C21BCD9D70004C5B45 /* CurrentTime.cpp in Sources */,
+				A3CA45C31BCD9D70004C5B45 /* DataLog.cpp in Sources */,
+				A3CA45C41BCD9D70004C5B45 /* DateMath.cpp in Sources */,
+				A3CA45C51BCD9D70004C5B45 /* DecimalNumber.cpp in Sources */,
+				A3CA45C61BCD9D70004C5B45 /* diy-fp.cc in Sources */,
+				A3CA45C71BCD9D70004C5B45 /* double-conversion.cc in Sources */,
+				A3CA45C81BCD9D70004C5B45 /* dtoa.cpp in Sources */,
+				A3CA45C91BCD9D70004C5B45 /* FastBitVector.cpp in Sources */,
+				A3CA45CA1BCD9D70004C5B45 /* DynamicAnnotations.cpp in Sources */,
+				A3CA45CB1BCD9D70004C5B45 /* fast-dtoa.cc in Sources */,
+				A3CA45CC1BCD9D70004C5B45 /* FastMalloc.cpp in Sources */,
+				A3CA45CD1BCD9D70004C5B45 /* StringImplCF.cpp in Sources */,
+				A3CA45CE1BCD9D70004C5B45 /* AtomicStringCF.cpp in Sources */,
+				A3CA45CF1BCD9D70004C5B45 /* FilePrintStream.cpp in Sources */,
+				A3CA45D01BCD9D70004C5B45 /* fixed-dtoa.cc in Sources */,
+				A3CA45D11BCD9D70004C5B45 /* FunctionDispatcher.cpp in Sources */,
+				A3CA45D21BCD9D70004C5B45 /* GregorianDateTime.cpp in Sources */,
+				A3CA45D31BCD9D70004C5B45 /* HashTable.cpp in Sources */,
+				A3CA45D41BCD9D70004C5B45 /* MainThread.cpp in Sources */,
+				A3CA45D51BCD9D70004C5B45 /* MainThreadMac.mm in Sources */,
+				A3CA45D61BCD9D70004C5B45 /* MD5.cpp in Sources */,
+				A3CA45D71BCD9D70004C5B45 /* MediaTime.cpp in Sources */,
+				A3CA45D81BCD9D70004C5B45 /* MetaAllocator.cpp in Sources */,
+				A3CA45D91BCD9D70004C5B45 /* NumberOfCores.cpp in Sources */,
+				A3CA45DA1BCD9D70004C5B45 /* OSAllocatorPosix.cpp in Sources */,
+				A3CA45DB1BCD9D70004C5B45 /* OSRandomSource.cpp in Sources */,
+				A3CA45DC1BCD9D70004C5B45 /* PageAllocationAligned.cpp in Sources */,
+				A3CA45DD1BCD9D70004C5B45 /* PageBlock.cpp in Sources */,
+				A3CA45DE1BCD9D70004C5B45 /* PrintStream.cpp in Sources */,
+				A3CA45DF1BCD9D70004C5B45 /* StringImplMac.mm in Sources */,
+				A3CA45E01BCD9D70004C5B45 /* RAMSize.cpp in Sources */,
+				A3CA45E11BCD9D70004C5B45 /* RandomNumber.cpp in Sources */,
+				A3CA45E21BCD9D70004C5B45 /* RefCountedLeakCounter.cpp in Sources */,
+				A3CA45E31BCD9D70004C5B45 /* RunLoop.cpp in Sources */,
+				A3CA45E41BCD9D70004C5B45 /* RunLoopCF.cpp in Sources */,
+				A3CA45E51BCD9D70004C5B45 /* RunLoopTimerCF.cpp in Sources */,
+				A3CA45E61BCD9D70004C5B45 /* SchedulePairCF.cpp in Sources */,
+				A3CA45E71BCD9D70004C5B45 /* StringMac.mm in Sources */,
+				A3CA45E81BCD9D70004C5B45 /* SchedulePairMac.mm in Sources */,
+				A3CA45E91BCD9D70004C5B45 /* SHA1.cpp in Sources */,
+				A3CA45EA1BCD9D70004C5B45 /* SixCharacterHash.cpp in Sources */,
+				A3CA45EB1BCD9D70004C5B45 /* StackBounds.cpp in Sources */,
+				A3CA45EC1BCD9D70004C5B45 /* StackStats.cpp in Sources */,
+				A3CA45ED1BCD9D70004C5B45 /* StringBuilder.cpp in Sources */,
+				A3CA45EE1BCD9D70004C5B45 /* StringImpl.cpp in Sources */,
+				A3CA45EF1BCD9D70004C5B45 /* StringPrintStream.cpp in Sources */,
+				A3CA45F01BCD9D70004C5B45 /* StringStatics.cpp in Sources */,
+				A3CA45F11BCD9D70004C5B45 /* strtod.cc in Sources */,
+				A3CA45F21BCD9D70004C5B45 /* TCSystemAlloc.cpp in Sources */,
+				A3CA45F31BCD9D70004C5B45 /* ThreadIdentifierDataPthreads.cpp in Sources */,
+				A3CA45F41BCD9D70004C5B45 /* Threading.cpp in Sources */,
+				A3CA45F51BCD9D70004C5B45 /* ThreadingPthreads.cpp in Sources */,
+				A3CA45F61BCD9D70004C5B45 /* UTF8.cpp in Sources */,
+				A3CA45F71BCD9D70004C5B45 /* WebCoreThread.cpp in Sources */,
+				A3CA45F81BCD9D70004C5B45 /* WTFString.cpp in Sources */,
+				A3CA45F91BCD9D70004C5B45 /* WTFThreadData.cpp in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -1276,6 +1823,11 @@
 			isa = PBXTargetDependency;
 			target = 65AFA16F1630B977003D723C /* Copy WTF Headers */;
 			targetProxy = 10EAA7041889E93100DEB161 /* PBXContainerItemProxy */;
+		};
+		A3CA45AE1BCD9D70004C5B45 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 65AFA16F1630B977003D723C /* Copy WTF Headers */;
+			targetProxy = A3CA45AF1BCD9D70004C5B45 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -1356,6 +1908,39 @@
 			};
 			name = Production;
 		};
+		A3CA46AD1BCD9D70004C5B45 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 10EAA7011889E91800DEB161 /* WTF-iOS-Static.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Debug;
+		};
+		A3CA46AE1BCD9D70004C5B45 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 10EAA7011889E91800DEB161 /* WTF-iOS-Static.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Release;
+		};
+		A3CA46AF1BCD9D70004C5B45 /* Production */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 10EAA7011889E91800DEB161 /* WTF-iOS-Static.xcconfig */;
+			buildSettings = {
+				ARCHS = "$(ARCHS_STANDARD_INCLUDING_64_BIT)";
+				PRODUCT_NAME = "$(TARGET_NAME:rfc1034identifier)";
+				SDKROOT = appletvos;
+				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
+			};
+			name = Production;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -1385,6 +1970,16 @@
 				65AFA2891630B977003D723C /* Debug */,
 				65AFA28A1630B977003D723C /* Release */,
 				65AFA28B1630B977003D723C /* Production */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Production;
+		};
+		A3CA46AC1BCD9D70004C5B45 /* Build configuration list for PBXNativeTarget "WTF tvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				A3CA46AD1BCD9D70004C5B45 /* Debug */,
+				A3CA46AE1BCD9D70004C5B45 /* Release */,
+				A3CA46AF1BCD9D70004C5B45 /* Production */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Production;

--- a/WTF/WTF.xcodeproj/xcshareddata/xcschemes/WTF tvOS.xcscheme
+++ b/WTF/WTF.xcodeproj/xcshareddata/xcschemes/WTF tvOS.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "A3CA45AD1BCD9D70004C5B45"
+               BuildableName = "libWTF-tvOS.a"
+               BlueprintName = "WTF tvOS"
+               ReferencedContainer = "container:WTF.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3CA45AD1BCD9D70004C5B45"
+            BuildableName = "libWTF-tvOS.a"
+            BlueprintName = "WTF tvOS"
+            ReferencedContainer = "container:WTF.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "A3CA45AD1BCD9D70004C5B45"
+            BuildableName = "libWTF-tvOS.a"
+            BlueprintName = "WTF tvOS"
+            ReferencedContainer = "container:WTF.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/maketvos.py
+++ b/maketvos.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+
+import argparse
+import logging
+import os
+import tempfile
+import shutil
+import subprocess
+from xcodebuildtvos import FrameworkBuild
+
+"""Script to build JavaScriptCore.framework for tvOS."""
+
+__author__ = "Dario Segura"
+__email__ = "dario@trompogames.com"
+
+
+class PebbleKitiOSException (Exception):
+    pass
+
+
+def build(out, derived_data_path):
+    outdir = out if out else tempfile.mkdtemp()
+
+    jsc = FrameworkBuild(workspace="JavaScriptCore-iOS.xcworkspace",
+                         scheme="JavaScriptCore tvOS",
+                         name="JavaScriptCore-tvOS",
+                         conf="Production",
+                         outdir=outdir,
+                         derived_data_path=derived_data_path)
+    jsc.build()
+
+    # FIXME: wtf headers are copied... remove them:
+    shutil.rmtree(os.path.join(outdir, 'JavaScriptCore-tvOS.framework',
+                               'Headers', 'wtf'))
+
+    return outdir
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Build'
+                                     ' JavaScriptCore-tvOS.framework')
+    parser.add_argument('--out', default=None, type=str,
+                        help="Output directory. Defaults to a random' \
+                        ' temporary folder.")
+    parser.add_argument('--derived-data', default=None, type=str,
+                        help="Derived data directory. Defaults to a random' \
+                        ' temporary folder.")
+    parser.add_argument('--verbose', action='store_const', default=False,
+                        const=True, help="Enable verbose logging.")
+    parser.add_argument('--no-open', action='store_const', default=True,
+                        const=False, help="Use `--no-open` to skip' \
+                        ' revealing the built product in Finder.")
+    args = parser.parse_args()
+
+    log_level = logging.INFO
+    if args.verbose:
+        log_level = logging.DEBUG
+    logging.basicConfig(format='[%(levelname)-8s] %(message)s',
+                        level=log_level)
+
+    outdir = build(args.out, args.derived_data)
+
+    if args.no_open:
+        os.system("open %s" % outdir)

--- a/maketvos.py
+++ b/maketvos.py
@@ -23,14 +23,14 @@ def build(out, derived_data_path):
 
     jsc = FrameworkBuild(workspace="JavaScriptCore-iOS.xcworkspace",
                          scheme="JavaScriptCore tvOS",
-                         name="JavaScriptCore-tvOS",
+                         name="JavaScriptCore",
                          conf="Production",
                          outdir=outdir,
                          derived_data_path=derived_data_path)
     jsc.build()
 
     # FIXME: wtf headers are copied... remove them:
-    shutil.rmtree(os.path.join(outdir, 'JavaScriptCore-tvOS.framework',
+    shutil.rmtree(os.path.join(outdir, 'JavaScriptCore.framework',
                                'Headers', 'wtf'))
 
     return outdir

--- a/xcodebuildtvos.py
+++ b/xcodebuildtvos.py
@@ -1,0 +1,194 @@
+#!/usr/bin/env python
+
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+
+"""Python wrapper around the xcodebuild command line program."""
+
+__author__ = "Martijn The"
+__email__ = "martijn@getpebble.com"
+
+DEFAULT_SDK_VERSION = "7.0"
+
+
+class PebbleXcodeBuildException (Exception):
+    pass
+
+
+class XcodeBuild(object):
+    sdk_version = ""
+    conf = None
+    archs = None
+    project = None
+    scheme = None
+    derived_data_path = None
+    is_built = False
+
+    def __init__(self, project, derived_data_path=None):
+        self.project = project
+        self.derived_data_path = derived_data_path or tempfile.mkdtemp()
+        self.build_settings = {}
+
+    def _pre_build_sanity_check(self):
+        if self.scheme is None:
+            raise PebbleXcodeBuildException("No scheme set!")
+        if self.is_built:
+            raise PebbleXcodeBuildException("Already built!")
+
+    def _get_sdk_string(self):
+        is_device = len([arch for arch in self.archs
+                         if arch.startswith("arm")]) > 0
+        is_simulator = len([arch for arch in self.archs
+                            if arch.startswith("i386") or
+                            arch.startswith("x86_64")]) > 0
+        if is_device and is_simulator:
+            raise PebbleXcodeBuildException("Can't build for Device and"
+                                            "Simulator in one go! (archs=%s)" %
+                                            self.archs)
+        platform = ("appletvos" if is_device else "appletvsimulator")
+        return platform + self.sdk_version
+
+    def _get_params(self):
+        params = []
+        if self.project:
+            params.extend(("-project", self.project))
+        if self.scheme:
+            params.extend(("-scheme", self.scheme))
+            params.extend(("-derivedDataPath", self.derived_data_path))
+        if self.conf:
+            params.extend(("-configuration", self.conf))
+        if self.archs:
+            concat_archs = " ".join(self.archs)
+            params.append("ARCHS=%s" % concat_archs)
+            # Auto-select SDK if archs is set:
+            sdk = self._get_sdk_string()
+            params.extend(("-sdk", sdk))
+        return params
+
+    def _xcodebuild(self, *actions):
+        self._pre_build_sanity_check()
+        params = self._get_params()
+        base_cmd = ["xcodebuild"] + params
+        actions_cmd = base_cmd + list(actions)
+        logging.debug("Executing: %s" % " ".join(actions_cmd))
+        if subprocess.call(actions_cmd):
+            raise PebbleXcodeBuildException("Build failed. xcodebuild exited"
+                                            "with non-zero return code (%s)" %
+                                            self.project)
+        # Collect the build settings that were used:
+        process = subprocess.Popen(base_cmd + ["-showBuildSettings"],
+                                   stdout=subprocess.PIPE)
+        if process.returncode:
+            raise PebbleXcodeBuildException("Gettings settings failed."
+                                            " xcodebuild exited with non-zero"
+                                            " return code (%s)" % self.project)
+        out = process.stdout.read()
+        settings_list = re.findall('\s*([A-Z_]+)\s*=\s*(.*)',
+                                   out, re.MULTILINE)
+        self.build_settings = {pair[0]: pair[1] for pair in settings_list}
+
+        self.is_built = True
+
+    def build(self):
+        self._xcodebuild("build")
+
+    def _check_is_built(self):
+        if not self.is_built:
+            raise PebbleXcodeBuildException("Cannot be accessed before build()"
+                                            "has been finished.")
+
+    def _path_from_build_settings_components(self, *setting_names):
+        self._check_is_built()
+        components = [self.build_settings[n] for n in setting_names]
+        # We want to treat absolute components as relative paths
+        concat_path = os.sep.join(components)
+        return os.path.normpath(concat_path)
+
+    def built_product_path(self):
+        return self._path_from_build_settings_components("BUILT_PRODUCTS_DIR",
+                                                         "FULL_PRODUCT_NAME")
+
+    def public_headers_path(self):
+        args = ("BUILT_PRODUCTS_DIR", "PUBLIC_HEADERS_FOLDER_PATH")
+        return self._path_from_build_settings_components(*args)
+
+
+class FrameworkBuild(object):
+    def __init__(self, project=None, workspace=None, scheme=None,
+                 conf="Release", outdir=None, name=None,
+                 derived_data_path=None):
+        self.scheme = scheme
+        self.name = name
+        self.devicebuildarm64 = XcodeBuild(project, derived_data_path=None if derived_data_path is None else os.path.join(derived_data_path, "arm64"))
+        self.simulatorbuild64 = XcodeBuild(project, derived_data_path=None if derived_data_path is None else os.path.join(derived_data_path, "x86_64"))
+        self.outdir = outdir
+        for (bld, archs) in [self.devicebuildarm64, ["arm64"]], \
+                            [self.simulatorbuild64, ["x86_64"]]:
+            bld.archs = archs
+            bld.scheme = scheme
+            bld.conf = conf
+
+    def build(self):
+        name = self.name or self.scheme
+        if " " in name:
+            name = name.replace(" ", "-")
+
+        # Run the builds of the libraries:
+        self.devicebuildarm64.build()
+        self.simulatorbuild64.build()
+
+        # Create the framework directory structure:
+        temp_dir = tempfile.mkdtemp()
+        framework_name = name + ".framework"
+        framework_dir = os.path.join(temp_dir, framework_name)
+        versions_dir = os.path.join(framework_dir, "Versions")
+        a_dir = os.path.join(versions_dir, "A")
+        lib_path = os.path.join(a_dir, name)
+        headers_dir = os.path.join(a_dir, "Headers")
+        os.makedirs(headers_dir)
+        os.symlink("A", os.path.join(versions_dir, "Current"))
+        os.symlink(os.path.join("Versions", "Current", "Headers"),
+                   os.path.join(framework_dir, "Headers"))
+        os.symlink(os.path.join("Versions", "Current", name),
+                   os.path.join(framework_dir, name))
+
+        # Move public headers:
+        for filename in os.listdir(self.devicebuildarm64.public_headers_path()):
+            shutil.move(os.path.join(self.devicebuildarm64.public_headers_path(), filename), headers_dir)
+        #shutil.move(self.devicebuildarm64.public_headers_path(), headers_dir)
+
+        # Use lipo to create one fat static library:
+        lipo_cmd = ["lipo", "-create",
+                    self.devicebuildarm64.built_product_path(),
+                    self.simulatorbuild64.built_product_path(),
+                    "-output", lib_path]
+        logging.debug("Executing: %s" % " ".join(lipo_cmd))
+        if subprocess.call(lipo_cmd):
+            raise PebbleXcodeBuildException("lipo failed")
+
+        # Move to outdir:
+        if self.outdir:
+            if not os.path.exists(self.outdir):
+                os.makedirs(self.outdir)
+            self._built_product_path = os.path.join(self.outdir,
+                                                    framework_name)
+            self._public_headers_path = os.path.join(self.outdir,
+                                                     framework_name,
+                                                     "Versions",
+                                                     "A", "Headers")
+            if os.path.exists(self._built_product_path):
+                shutil.rmtree(self._built_product_path)
+            shutil.move(framework_dir, self._built_product_path)
+        else:
+            self._built_product_path = framework_dir
+            self._public_headers_path = headers_dir
+
+    def built_product_path(self):
+        return self._built_product_path
+
+    def public_headers_path(self):
+        return self._public_headers_path


### PR DESCRIPTION
This PR adds compatibility for tvOS by configuring the project files and adding a new script: `maketvos.py` which builds `JavaScriptCore-tvOS.framework` that can be used in tvOS projects.

